### PR TITLE
Fix sigs.k8s.io/cluster-api to the last pre-CRDs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1031,8 +1031,7 @@
   revision = "c01ed926f1243ac17a23a66f67da7fbdb2e2e298"
 
 [[projects]]
-  branch = "master"
-  digest = "1:9c510bf7fbb7c80ee1e41252bc08dcd82d24048be47e2b7c212e2cda4e2a8fa7"
+  digest = "1:08a06bcc698f1c308d3a80aa36bd98f76913dfc8b069c45537bcad465454a688"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "pkg/apis/cluster",
@@ -1043,7 +1042,7 @@
     "pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1",
   ]
   pruneopts = ""
-  revision = "f302034cfa525bd57a891532e761f742687e5392"
+  revision = "f31486484d5b33c785540eeaffd47fe57832aef5"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,4 +39,5 @@
 
 [[constraint]]
   name = "sigs.k8s.io/cluster-api"
-  branch = "master"
+  # The last revision before CRDs
+  revision = "f31486484d5b33c785540eeaffd47fe57832aef5"

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -55,7 +55,7 @@ type ClusterSpec struct {
 	// their own versioned API types that should be
 	// serialized/deserialized from this field.
 	// +optional
-	ProviderConfig ProviderConfig `json:"providerConfig"`
+	ProviderConfig ProviderConfig `json:"providerConfig,omitempty"`
 }
 
 // ClusterNetworkingConfig specifies the different networking

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/common_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/common_types.go
@@ -33,7 +33,7 @@ type ProviderConfig struct {
 	// Source for the provider configuration. Cannot be used if value is
 	// not empty.
 	// +optional
-	ValueFrom *ProviderConfigSource `json:valueFrom,omitempty`
+	ValueFrom *ProviderConfigSource `json:"valueFrom,omitempty"`
 }
 
 // ProviderConfigSource represents a source for the provider-specific

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/error/requeue_error.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/error/requeue_error.go
@@ -30,5 +30,5 @@ type RequeueAfterError struct {
 
 // Error implements the error interface
 func (e *RequeueAfterError) Error() string {
-	return fmt.Sprintf("requeue cluster in: %s", e.RequeueAfter)
+	return fmt.Sprintf("requeue in: %s", e.RequeueAfter)
 }

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machine/controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machine/controller.go
@@ -138,7 +138,7 @@ func (c *MachineControllerImpl) Reconcile(machine *clusterv1.Machine) error {
 		err = c.update(m)
 		if err != nil {
 			if requeueErr, ok := err.(*controllerError.RequeueAfterError); ok {
-				glog.Infof("Actuator returned requeue after error: %v", requeueErr)
+				glog.Infof("Actuator returned requeue-after error: %v", requeueErr)
 				return c.enqueueAfter(machine, requeueErr.RequeueAfter)
 			}
 		}


### PR DESCRIPTION
The actuator repos still relies on deps of `sigs.k8s.io/cluster-api` without the CRDs.