### PR TITLE
Pass libvirt PK to the machine controller

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -1034,7 +1034,7 @@ func ClusterAPIControllersDeployment(clusterAPINamespace, actuatorImage string, 
 				},
 			},
 		})
-		deployment.Spec.Template.Spec.Containers[1].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[1].VolumeMounts, apiv1.VolumeMount{
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, apiv1.VolumeMount{
 			Name:      ActuatorPrivateKey,
 			MountPath: "/root/.ssh/actuator.pem",
 			ReadOnly:  true,


### PR DESCRIPTION
Leftover after the migration to CRD based cluster-api. Not affecting AWS, only libvirt.