### PR TITLE
Add missing subresource to CRDs

### DIFF
--- a/pkg/manifests/manifests.go
+++ b/pkg/manifests/manifests.go
@@ -36,6 +36,9 @@ func ClusterCRDManifest() *v1beta1.CustomResourceDefinition {
 				Kind:   "Cluster",
 			},
 			Scope: "Namespaced",
+			Subresources: &v1beta1.CustomResourceSubresources{
+				Status: &v1beta1.CustomResourceSubresourceStatus{},
+			},
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
 					Properties: map[string]v1beta1.JSONSchemaProps{
@@ -311,6 +314,9 @@ func MachineSetCRDManifest() *v1beta1.CustomResourceDefinition {
 				Kind:   "MachineSet",
 			},
 			Scope: v1beta1.ResourceScope("Namespaced"),
+			Subresources: &v1beta1.CustomResourceSubresources{
+				Status: &v1beta1.CustomResourceSubresourceStatus{},
+			},
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
 					Properties: map[string]v1beta1.JSONSchemaProps{
@@ -458,6 +464,9 @@ func MachineDeploymentCRDManifest() *v1beta1.CustomResourceDefinition {
 				Kind:   "MachineDeployment",
 			},
 			Scope: "Namespaced",
+			Subresources: &v1beta1.CustomResourceSubresources{
+				Status: &v1beta1.CustomResourceSubresourceStatus{},
+			},
 			Validation: &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
 					Properties: map[string]v1beta1.JSONSchemaProps{


### PR DESCRIPTION
For machineset, machinedeployment and cluster

https://github.com/openshift/machine-api-operator/blob/master/owned-manifests/cluster.crd.yaml#L14-L15 a similar.

Follow up of https://github.com/openshift/cluster-api-actuator-pkg/pull/16