### PR TITLE
deps: switch cluster-api dependency to use master branch

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,13 +43,12 @@ required = [
 
 [[constraint]]
   name = "github.com/openshift/cluster-api"
-  revision = "91fca585a85b163ddfd119fd09c128c9feadddca"
+  revision = "0c3e884db79556cf786aa8436f5be977ef10c211"
 
 # We need to specify fsnotify source to avoid dep panic
 [[override]]
   name = "gopkg.in/fsnotify.v1"
   source = "https://github.com/fsnotify/fsnotify.git"
-
 
 [[override]]
   name = "k8s.io/api"


### PR DESCRIPTION
Changing commit revision to point to openshift/cluster-api commit from master branch instead of `release-4.0` branch.

/assign @enxebre @ingvagabund 

![image](https://user-images.githubusercontent.com/3531758/53179977-06de4380-35f5-11e9-9d98-9c8c1c15be60.png)
