### PR TITLE
[autoscaling]: print which machines actually reference a node

### DIFF
--- a/pkg/e2e/autoscaler/autoscaler.go
+++ b/pkg/e2e/autoscaler/autoscaler.go
@@ -302,6 +302,7 @@ var _ = g.Describe("[Feature:Machines] Autoscaler should", func() {
 					glog.Errorf("Machine %q does not have node reference set", machine.Name)
 					return false, nil
 				}
+				glog.Infof("Machine %q is linked to node %q", machine.Name, machine.Status.NodeRef.Name)
 				nodeCounter++
 			}
 


### PR DESCRIPTION
To be able to count how many machines are in a node group
and how many nodes are actually linked. Autoscaling scale out
is failing either due to a node taking too much time to register
or for node labels not being properly propagated from machines.