### PR TITLE
[autoscaler] scale out: print target machineset replicas

### DIFF
--- a/pkg/e2e/autoscaler/autoscaler.go
+++ b/pkg/e2e/autoscaler/autoscaler.go
@@ -306,7 +306,17 @@ var _ = g.Describe("[Feature:Machines] Autoscaler should", func() {
 				nodeCounter++
 			}
 
-			glog.Infof("Expecting at least one new node to come up. Initial number of node group nodes: %d. Current number of nodes in the group: %d", nodeGroupInitialTotalNodes, nodeCounter)
+			msKey := types.NamespacedName{
+				Namespace: e2e.TestContext.MachineApiNamespace,
+				Name:      targetMachineSet.Name,
+			}
+			ms := &mapiv1beta1.MachineSet{}
+			if err := client.Get(context.TODO(), msKey, ms); err != nil {
+				glog.Errorf("error querying api for clusterAutoscaler object: %v, retrying...", err)
+				return false, nil
+			}
+
+			glog.Infof("Expecting at least one new node to come up. Initial number of node group nodes: %d. Current number of nodes in the group: %d. Target machineset replicas: %d\n", nodeGroupInitialTotalNodes, nodeCounter, *ms.Spec.Replicas)
 			return nodeCounter > nodeGroupInitialTotalNodes, nil
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
For some reason a machine labeled with scale out test id gets lost.
Or, machine with the label gets removed.
Thus, printing the curreny number of target machine set replicas
to decide if a machine is really deleted or just the label is lost.