### PR TITLE
Abstract function for 'have machines resources backing nodes' story

### DIFF
--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -44,9 +44,8 @@ var _ = g.Describe("[Feature:Machines] Machines should", func() {
 				return false, nil
 			}
 
-			// Every machine needs to be linked to a node, though some nodes do not have to linked to any machines
-			glog.Infof("Expecting at least the same number of machines as nodes, have %v nodes and %v machines", len(nodeList.Items), len(machineList.Items))
-			if len(machineList.Items) > len(nodeList.Items) {
+			glog.Infof("Expecting the same number of machines and nodes, have %d nodes and %d machines", len(nodeList.Items), len(machineList.Items))
+			if len(machineList.Items) != len(nodeList.Items) {
 				return false, nil
 			}
 

--- a/pkg/e2e/infra/utils.go
+++ b/pkg/e2e/infra/utils.go
@@ -1,0 +1,65 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
+	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	controllernode "github.com/openshift/cluster-api/pkg/controller/node"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func isOneMachinePerNode(client runtimeclient.Client) bool {
+	listOptions := runtimeclient.ListOptions{
+		Namespace: e2e.TestContext.MachineApiNamespace,
+	}
+	machineList := mapiv1beta1.MachineList{}
+	nodeList := corev1.NodeList{}
+
+	if err := wait.PollImmediate(5*time.Second, e2e.WaitShort, func() (bool, error) {
+		if err := client.List(context.TODO(), &listOptions, &machineList); err != nil {
+			glog.Errorf("Error querying api for machineList object: %v, retrying...", err)
+			return false, nil
+		}
+		if err := client.List(context.TODO(), &listOptions, &nodeList); err != nil {
+			glog.Errorf("Error querying api for nodeList object: %v, retrying...", err)
+			return false, nil
+		}
+
+		glog.Infof("Expecting the same number of machines and nodes, have %d nodes and %d machines", len(nodeList.Items), len(machineList.Items))
+		if len(machineList.Items) != len(nodeList.Items) {
+			return false, nil
+		}
+
+		nodeNameToMachineAnnotation := make(map[string]string)
+		for _, node := range nodeList.Items {
+			if _, ok := node.Annotations[controllernode.MachineAnnotationKey]; !ok {
+				glog.Errorf("Node %q does not have a MachineAnnotationKey %q, retrying...", node.Name, controllernode.MachineAnnotationKey)
+				return false, nil
+			}
+			nodeNameToMachineAnnotation[node.Name] = node.Annotations[controllernode.MachineAnnotationKey]
+		}
+		for _, machine := range machineList.Items {
+			if machine.Status.NodeRef == nil {
+				glog.Errorf("Machine %q has no NodeRef, retrying...", machine.Name)
+				return false, nil
+			}
+			nodeName := machine.Status.NodeRef.Name
+			if nodeNameToMachineAnnotation[nodeName] != fmt.Sprintf("%s/%s", e2e.TestContext.MachineApiNamespace, machine.Name) {
+				glog.Errorf("Node name %q does not match expected machine name %q, retrying...", nodeName, machine.Name)
+				return false, nil
+			}
+			glog.Infof("Machine %q is linked to node %q", machine.Name, nodeName)
+		}
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error checking isOneMachinePerNode: %v", err)
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Abstract function for 'have machines resources backing nodes' story
Enforce same number of nodes and machines Fixed by https://github.com/openshift/cluster-api-actuator-pkg/pull/41/commits/3ed9405d07fc4403103ab822ea7b6b61bb4f4091