### PR TITLE
Improve Taints validation

### DIFF
--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -9,9 +9,7 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
-	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -31,84 +29,69 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("have ability to additively reconcile taints", func() {
+	g.It("have ability to additively reconcile taints from machine to nodes", func() {
 		var err error
 		client, err := e2e.LoadClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By("Verify machine taints are getting applied to node")
-		err = func() error {
-			listOptions := runtimeclient.ListOptions{
-				Namespace: e2e.TestContext.MachineApiNamespace,
-			}
-			machineList := mapiv1beta1.MachineList{}
+		machines, err := getMachines(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(machines)).To(o.BeNumerically(">", 0))
+		machine := machines[0]
+		originalMachineTaints := machine.Spec.Taints
+		g.By(fmt.Sprintf("getting machine %q", machine.Name))
 
-			if err := client.List(context.TODO(), &listOptions, &machineList); err != nil {
-				return fmt.Errorf("error querying api for machineList object: %v", err)
-			}
-			g.By("Got the machine list")
-			machine := machineList.Items[0]
-			if machine.Status.NodeRef == nil {
-				return fmt.Errorf("machine %s has no NodeRef", machine.Name)
-			}
-			g.By(fmt.Sprintf("Got the machine %s", machine.Name))
-			nodeName := machine.Status.NodeRef.Name
-			nodeKey := types.NamespacedName{
-				Namespace: e2e.TestContext.MachineApiNamespace,
-				Name:      nodeName,
-			}
-			node := &corev1.Node{}
+		node, err := getNodeFromMachine(client, machine)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		originalNodeTaints := node.Spec.Taints
+		g.By(fmt.Sprintf("getting the backed node %q", node.Name))
 
-			if err := client.Get(context.TODO(), nodeKey, node); err != nil {
-				return fmt.Errorf("error querying api for node object: %v", err)
-			}
-			g.By(fmt.Sprintf("Got the node %s from machine, %s", node.Name, machine.Name))
-			nodeTaint := corev1.Taint{
-				Key:    "not-from-machine",
-				Value:  "true",
-				Effect: corev1.TaintEffectNoSchedule,
-			}
-			// Do not remove any taint, just extend the list
-			// The test removes the nodes anyway, so the list will not grow over time much
-			node.Spec.Taints = append(node.Spec.Taints, nodeTaint)
-			if err := client.Update(context.TODO(), node); err != nil {
-				return fmt.Errorf("error updating node object with non-machine taint: %v", err)
-			}
-			g.By("Updated node object with taint")
-			machineTaint := corev1.Taint{
-				Key:    fmt.Sprintf("from-machine-%v", string(uuid.NewUUID())),
-				Value:  "true",
-				Effect: corev1.TaintEffectNoSchedule,
-			}
+		nodeTaint := corev1.Taint{
+			Key:    "not-from-machine",
+			Value:  "true",
+			Effect: corev1.TaintEffectNoSchedule,
+		}
+		g.By(fmt.Sprintf("updating node %q with taint: %v", node.Name, nodeTaint))
+		node.Spec.Taints = append(node.Spec.Taints, nodeTaint)
+		err = client.Update(context.TODO(), node)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			// Do not remove any taint, just extend the list
-			// The test removes the machine anyway, so the list will not grow over time much
-			machine.Spec.Taints = append(machine.Spec.Taints, machineTaint)
-			if err := client.Update(context.TODO(), &machine); err != nil {
-				return fmt.Errorf("error updating machine object with taint: %v", err)
-			}
+		machineTaint := corev1.Taint{
+			Key:    fmt.Sprintf("from-machine-%v", string(uuid.NewUUID())),
+			Value:  "true",
+			Effect: corev1.TaintEffectNoSchedule,
+		}
+		g.By(fmt.Sprintf("updating machine %q with taint: %v", machine.Name, machineTaint))
+		machine.Spec.Taints = append(machine.Spec.Taints, machineTaint)
+		err = client.Update(context.TODO(), &machine)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-			g.By("Updated machine object with taint")
-			var expectedTaints = sets.NewString("not-from-machine", machineTaint.Key)
-			err := wait.PollImmediate(1*time.Second, e2e.WaitLong, func() (bool, error) {
-				if err := client.Get(context.TODO(), nodeKey, node); err != nil {
-					glog.Errorf("error querying api for node object: %v", err)
-					return false, nil
-				}
-				glog.Info("Got the node again for verification of taints")
-				var observedTaints = sets.NewString()
-				for _, taint := range node.Spec.Taints {
-					observedTaints.Insert(taint.Key)
-				}
-				if expectedTaints.Difference(observedTaints).HasAny("not-from-machine", machineTaint.Key) == false {
-					glog.Infof("expected : %v, observed %v , difference %v, ", expectedTaints, observedTaints, expectedTaints.Difference(observedTaints))
-					return true, nil
-				}
-				glog.Infof("Did not find all expected taints on the node. Missing: %v", expectedTaints.Difference(observedTaints))
-				return false, nil
-			})
-			return err
-		}()
+		var expectedTaints = sets.NewString("not-from-machine", machineTaint.Key)
+		o.Eventually(func() bool {
+			glog.Info("Getting node from machine again for verification of taints")
+			node, err := getNodeFromMachine(client, machine)
+			if err != nil {
+				return false
+			}
+			var observedTaints = sets.NewString()
+			for _, taint := range node.Spec.Taints {
+				observedTaints.Insert(taint.Key)
+			}
+			if expectedTaints.Difference(observedTaints).HasAny("not-from-machine", machineTaint.Key) == false {
+				glog.Infof("Expected : %v, observed %v , difference %v, ", expectedTaints, observedTaints, expectedTaints.Difference(observedTaints))
+				return true
+			}
+			glog.Infof("Did not find all expected taints on the node. Missing: %v", expectedTaints.Difference(observedTaints))
+			return false
+		}, e2e.WaitMedium, 5*time.Second).Should(o.BeTrue())
+		// set back original taints
+		machine.Spec.Taints = originalMachineTaints
+		err = client.Update(context.TODO(), &machine)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		node, err = getNodeFromMachine(client, machine)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		node.Spec.Taints = originalNodeTaints
+		err = client.Update(context.TODO(), node)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -249,7 +249,11 @@ func waitForClusterSizeToBeHealthy(targetSize int) {
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	o.Eventually(func() int {
+		glog.Infof("Cluster size expected to be %d nodes", targetSize)
 		err := machineSetsSnapShot(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = nodesSnapShotLogs(client)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		finalClusterSize, err := getClusterSize(client)

--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -233,7 +233,7 @@ func waitForClusterSizeToBeHealthy(targetSize int) {
 
 	o.Eventually(func() int {
 		glog.Infof("Cluster size expected to be %d nodes", targetSize)
-		err := machineSetsSnapShot(client)
+		err := machineSetsSnapShotLogs(client)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		err = nodesSnapShotLogs(client)

--- a/pkg/e2e/infra/utils.go
+++ b/pkg/e2e/infra/utils.go
@@ -319,3 +319,41 @@ func getScaleClient() (scale.ScalesGetter, error) {
 	}
 	return scaleClient, nil
 }
+
+// nodesSnapShotLogs logs the state of all the nodes in the cluster
+func nodesSnapShotLogs(client runtimeclient.Client) error {
+	nodes, err := getNodes(client)
+	if err != nil {
+		return fmt.Errorf("error calling getNodes: %v", err)
+	}
+	for key := range nodes {
+		glog.Infof("Node %q. Ready: %t. Unschedulable: %t", nodes[key].Name, e2e.IsNodeReady(&nodes[key]), nodes[key].Spec.Unschedulable)
+	}
+	return nil
+}
+
+// getNodeList returns a nodeList object
+func getNodeList(client runtimeclient.Client) (*corev1.NodeList, error) {
+	nodeList := corev1.NodeList{}
+	listOptions := runtimeclient.ListOptions{}
+	if err := wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		if err := client.List(context.TODO(), &listOptions, &nodeList); err != nil {
+			glog.Errorf("error querying api for machineSetList object: %v, retrying...", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error calling getMachineSetList: %v", err)
+		return nil, err
+	}
+	return &nodeList, nil
+}
+
+// getNodes returns the list of nodes or an error
+func getNodes(client runtimeclient.Client) ([]corev1.Node, error) {
+	nodeList, err := getNodeList(client)
+	if err != nil {
+		return nil, fmt.Errorf("error getting nodeList: %v", err)
+	}
+	return nodeList.Items, nil
+}

--- a/pkg/e2e/infra/utils.go
+++ b/pkg/e2e/infra/utils.go
@@ -95,8 +95,8 @@ func getClusterSize(client runtimeclient.Client) (int, error) {
 	return len(nodeList.Items), nil
 }
 
-// machineSetsSnapShot logs the state of all the machineSets in the cluster
-func machineSetsSnapShot(client runtimeclient.Client) error {
+// machineSetsSnapShotLogs logs the state of all the machineSets in the cluster
+func machineSetsSnapShotLogs(client runtimeclient.Client) error {
 	machineSetList, err := getMachineSetList(client)
 	if err != nil {
 		return fmt.Errorf("error calling getMachineSetList: %v", err)

--- a/pkg/e2e/infra/utils.go
+++ b/pkg/e2e/infra/utils.go
@@ -157,6 +157,15 @@ func getMachineList(client runtimeclient.Client) (*mapiv1beta1.MachineList, erro
 	return &machineList, nil
 }
 
+// getMachines returns the list of machines or an error
+func getMachines(client runtimeclient.Client) ([]mapiv1beta1.Machine, error) {
+	machineList, err := getMachineList(client)
+	if err != nil {
+		return nil, fmt.Errorf("error getting machineList: %v", err)
+	}
+	return machineList.Items, nil
+}
+
 // getMachinesFromMachineSet returns an array of machines owned by a given machineSet
 func getMachinesFromMachineSet(client runtimeclient.Client, machineSet mapiv1beta1.MachineSet) ([]mapiv1beta1.Machine, error) {
 	machineList, err := getMachineList(client)


### PR DESCRIPTION
[Feature:Machines] Managed cluster should - have ability to additively reconcile taints from machine to nodes
- Add nodes snapshot
- Update test to rely on emerging DSL api
- Ensure original taints are restored at the end of the test
Goes after https://github.com/openshift/cluster-api-actuator-pkg/pull/43