### PR TITLE
Refactor deployments for operators

### DIFF
--- a/pkg/e2e/operators/machine-api-operator.go
+++ b/pkg/e2e/operators/machine-api-operator.go
@@ -1,17 +1,11 @@
 package operators
 
 import (
-	"context"
 	"fmt"
-	"time"
 
-	"github.com/golang/glog"
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
-	kappsapi "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var _ = g.Describe("[Feature:Operators] Machine API operator deployment should", func() {
@@ -29,36 +23,19 @@ var _ = g.Describe("[Feature:Operators] Machine API operator deployment should",
 		client, err := e2e.LoadClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		controllersDeploymentKey := types.NamespacedName{
-			Namespace: e2e.TestContext.MachineApiNamespace,
-			Name:      "clusterapi-manager-controllers",
-		}
-		initialDeployment := &kappsapi.Deployment{}
-		glog.Infof("Get deployment %q", controllersDeploymentKey.Name)
-		err = wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
-			if err := client.Get(context.TODO(), controllersDeploymentKey, initialDeployment); err != nil {
-				glog.Errorf("error querying api for Deployment object: %v, retrying...", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		deploymentName := "clusterapi-manager-controllers"
+		initialDeployment, err := getDeployment(client, deploymentName)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By(fmt.Sprintf("checking deployment %q is available", controllersDeploymentKey.Name))
-		o.Expect(isDeploymentAvailable(client, controllersDeploymentKey.Name)).To(o.BeTrue())
+		g.By(fmt.Sprintf("checking deployment %q is available", deploymentName))
+		o.Expect(isDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
 
-		g.By(fmt.Sprintf("deleting deployment %q", controllersDeploymentKey.Name))
-		err = wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
-			if err := client.Delete(context.TODO(), initialDeployment); err != nil {
-				glog.Errorf("error querying api for Deployment object: %v, retrying...", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		g.By(fmt.Sprintf("deleting deployment %q", deploymentName))
+		err = deleteDeployment(client, initialDeployment)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By(fmt.Sprintf("checking deployment %q is available again", controllersDeploymentKey.Name))
-		o.Expect(isDeploymentAvailable(client, controllersDeploymentKey.Name)).To(o.BeTrue())
+		g.By(fmt.Sprintf("checking deployment %q is available again", deploymentName))
+		o.Expect(isDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
 	})
 
 })

--- a/pkg/e2e/operators/utils.go
+++ b/pkg/e2e/operators/utils.go
@@ -2,6 +2,7 @@ package operators
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -14,7 +15,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func isDeploymentAvailable(client runtimeclient.Client, name string) bool {
+func getDeployment(client runtimeclient.Client, name string) (*kappsapi.Deployment, error) {
 	key := types.NamespacedName{
 		Namespace: e2e.TestContext.MachineApiNamespace,
 		Name:      name,
@@ -23,19 +24,43 @@ func isDeploymentAvailable(client runtimeclient.Client, name string) bool {
 
 	if err := wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
 		if err := client.Get(context.TODO(), key, d); err != nil {
-			glog.Errorf("Error querying api for Deployment object: %v, retrying...", err)
+			glog.Errorf("Error querying api for Deployment object %q: %v, retrying...", name, err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, fmt.Errorf("error getting deployment %q: %v", name, err)
+	}
+	return d, nil
+}
+
+func deleteDeployment(client runtimeclient.Client, deployment *kappsapi.Deployment) error {
+	return wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
+		if err := client.Delete(context.TODO(), deployment); err != nil {
+			glog.Errorf("error querying api for deployment object %q: %v, retrying...", deployment.Name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func isDeploymentAvailable(client runtimeclient.Client, name string) bool {
+	if err := wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
+		d, err := getDeployment(client, name)
+		if err != nil {
+			glog.Errorf("Error getting deployment: %v", err)
 			return false, nil
 		}
 		if d.Status.AvailableReplicas < 1 {
 			glog.Errorf("Deployment %q is not available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
 			return false, nil
 		}
+		glog.Infof("Deployment %q is available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
 		return true, nil
 	}); err != nil {
 		glog.Errorf("Error checking isDeploymentAvailable: %v", err)
 		return false
 	}
-	glog.Infof("Deployment %q is available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
 	return true
 }
 


### PR DESCRIPTION
Refactor deployments for operators continuing with the pattern:
- modeling dsl for manipulating objects
- Ginkgo consumes it and just make aotmic/eventually assertions