### PR TITLE
e2e/autoscaler: remove ActiveDeadlineSeconds from job definition

### DIFF
--- a/pkg/e2e/autoscaler/autoscaler.go
+++ b/pkg/e2e/autoscaler/autoscaler.go
@@ -26,7 +26,6 @@ func newWorkLoad() *batchv1.Job {
 	backoffLimit := int32(4)
 	completions := int32(50)
 	parallelism := int32(50)
-	activeDeadlineSeconds := int64(100)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "workload",
@@ -67,10 +66,9 @@ func newWorkLoad() *batchv1.Job {
 					},
 				},
 			},
-			ActiveDeadlineSeconds: &activeDeadlineSeconds,
-			BackoffLimit:          &backoffLimit,
-			Completions:           &completions,
-			Parallelism:           &parallelism,
+			BackoffLimit: &backoffLimit,
+			Completions:  &completions,
+			Parallelism:  &parallelism,
 		},
 	}
 }


### PR DESCRIPTION
The presence of this field was (always) causing the test to fail, or
at best be very flaky. The value specified in the job was 100s.

The autoscaler tests would start, the replica count would get bumped,
we would wait for the machine to become a node, but 100s would elapse
and (quoting from the docs):

 The ActiveDeadlineSeconds applies to the duration of the job, no
 matter how many Pods are created. Once a Job reaches
 activeDeadlineSeconds, all of its Pods are terminated and the Job
 status will become type: Failed with reason: DeadlineExceeded.

the job that triggered scale up would disappear (because
DeadlineExceeded).

At the next cluster-autoscaler scan interval (every 10s) the CA would
notice that there wasn't a need for the node it just created as there
are "No unschedulable pods". This would then initiate a scale down. As
the ScaleDownConfig specifies 10s for all of its timeout values, scale
down was for all intents and purposes immediate.

Our condition for success was that node count goes from 1 => 2. But,
once the job had disappeared and the corresponding node deleted due to
lack of demand, we were never reliably going to get to 2 nodes so the test
itself would eventually timeout and therefore overall failure.