### PR TITLE
e2e/autoscaler: Bump autoscaler workload timeout

### DIFF
--- a/pkg/e2e/autoscaler/autoscaler.go
+++ b/pkg/e2e/autoscaler/autoscaler.go
@@ -44,7 +44,7 @@ func newWorkLoad() *batchv1.Job {
 							Image: "busybox",
 							Command: []string{
 								"sleep",
-								"300",
+								"86400", // 1 day
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{


### PR DESCRIPTION
The purpose of the workload is to start enough pods that triggers the
cluster autoscaler to start scaling up. We don't ever want those pods
to complete - their purpose is to run effectively indefinitely. The
current timeout is 300s. I'm deliberately making this a much larger
value (1 day) so that the pods have no chance to run to completion.