### PR TITLE
Refactor machine-health-check tests

### DIFF
--- a/pkg/e2e/autoscaler/autoscaler.go
+++ b/pkg/e2e/autoscaler/autoscaler.go
@@ -61,7 +61,7 @@ func newWorkLoad() *batchv1.Job {
 					},
 					RestartPolicy: corev1.RestartPolicy("Never"),
 					NodeSelector: map[string]string{
-						"node-role.kubernetes.io/worker": "",
+						e2e.WorkerNodeRoleLabel: "",
 					},
 					Tolerations: []corev1.Toleration{
 						{

--- a/pkg/e2e/framework/common.go
+++ b/pkg/e2e/framework/common.go
@@ -15,11 +15,11 @@ import (
 )
 
 const (
-	WorkerRoleLabel = "node-role.kubernetes.io/worker"
-	WaitShort       = 1 * time.Minute
-	WaitMedium      = 3 * time.Minute
-	WaitLong        = 10 * time.Minute
-	RetryMedium     = 5 * time.Second
+	WorkerNodeRoleLabel = "node-role.kubernetes.io/worker"
+	WaitShort           = 1 * time.Minute
+	WaitMedium          = 3 * time.Minute
+	WaitLong            = 10 * time.Minute
+	RetryMedium         = 5 * time.Second
 
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil

--- a/pkg/e2e/framework/machinehealthcheck.go
+++ b/pkg/e2e/framework/machinehealthcheck.go
@@ -16,8 +16,6 @@ import (
 const (
 	// KubeletKillerPodName contains the name of the pod that stops kubelet process
 	KubeletKillerPodName = "kubelet-killer"
-	// NodeWorkerLabel contains label that every worker node has
-	NodeWorkerLabel = "node-role.kubernetes.io/worker"
 	// MachineHealthCheckName contains the name of the machinehealthcheck used for tests
 	MachineHealthCheckName = "workers-check"
 )

--- a/pkg/e2e/framework/nodes.go
+++ b/pkg/e2e/framework/nodes.go
@@ -1,0 +1,33 @@
+package framework
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetWorkerNodes returns all nodes with the nodeWorkerRoleLabel label
+func GetWorkerNodes(client runtimeclient.Client) ([]corev1.Node, error) {
+	listOptions := runtimeclient.ListOptions{
+		Namespace: TestContext.MachineApiNamespace,
+	}
+	listOptions.MatchingLabels(map[string]string{WorkerNodeRoleLabel: ""})
+	workerNodes := &corev1.NodeList{}
+	err := client.List(context.TODO(), &listOptions, workerNodes)
+	if err != nil {
+		return nil, err
+	}
+	return workerNodes.Items, nil
+}
+
+// FilterReadyNodes fileter the list of nodes and returns the list with ready nodes
+func FilterReadyNodes(nodes []corev1.Node) []corev1.Node {
+	var readyNodes []corev1.Node
+	for _, n := range nodes {
+		if IsNodeReady(&n) {
+			readyNodes = append(readyNodes, n)
+		}
+	}
+	return readyNodes
+}

--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -26,8 +26,8 @@ import (
 )
 
 var nodeDrainLabels = map[string]string{
-	e2e.WorkerRoleLabel:  "",
-	"node-draining-test": string(uuid.NewUUID()),
+	e2e.WorkerNodeRoleLabel: "",
+	"node-draining-test":    string(uuid.NewUUID()),
 }
 
 func replicationControllerWorkload(namespace string) *corev1.ReplicationController {
@@ -195,9 +195,13 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 		err = waitForClusterSizeToBeHealthy(client, initialClusterSize)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		workerNode, err := getWorkerNode(client)
+		g.By("getting worker node")
+		workerNodes, err := e2e.GetWorkerNodes(client)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		workerMachine, err := getMachineFromNode(client, workerNode)
+		o.Expect(workerNodes).ToNot(o.BeEmpty())
+
+		workerNode := &workerNodes[0]
+		workerMachine, err := e2e.GetMachineFromNode(client, workerNode)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		g.By(fmt.Sprintf("deleting machine object %q", workerMachine.Name))
 		err = deleteMachine(client, workerMachine)

--- a/pkg/e2e/machinehealthcheck/machinehealthcheck.go
+++ b/pkg/e2e/machinehealthcheck/machinehealthcheck.go
@@ -59,47 +59,27 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", f
 
 		isKubemarkProvider, err := e2e.IsKubemarkProvider(client)
 		Expect(err).ToNot(HaveOccurred())
+
+		// TODO: remove once we can create or update kubemark machines
+		// that will give use possibility to make this test work
 		if isKubemarkProvider {
 			glog.V(2).Info("Can not run this tests with the 'KubeMark' provider")
 			Skip("Can not run this tests with the 'KubeMark' provider")
 		}
 
-		listOptions := runtimeclient.ListOptions{
-			Namespace: e2e.TestContext.MachineApiNamespace,
-		}
-		listOptions.SetLabelSelector(fmt.Sprintf("%s=", e2e.NodeWorkerLabel))
-		workers := &corev1.NodeList{}
-		err = client.List(context.TODO(), &listOptions, workers)
+		workerNodes, err := e2e.GetWorkerNodes(client)
 		Expect(err).ToNot(HaveOccurred())
 
-		numberOfReadyWorkers = 0
-		workerNode = nil
-		for i, w := range workers.Items {
-			readyCond := conditions.GetNodeCondition(&w, corev1.NodeReady)
-			if readyCond.Status == corev1.ConditionTrue {
-				numberOfReadyWorkers++
-				if workerNode == nil {
-					workerNode = &workers.Items[i]
-					glog.V(2).Infof("Worker node %s", workerNode.Name)
-				}
-			}
-		}
-		Expect(workerNode).ToNot(BeNil())
+		readyWorkerNodes := e2e.FilterReadyNodes(workerNodes)
+		Expect(readyWorkerNodes).ToNot(BeEmpty())
 
-		listOptions = runtimeclient.ListOptions{
-			Namespace: e2e.TestContext.MachineApiNamespace,
-		}
-		machineList := &mapiv1beta1.MachineList{}
-		err = client.List(context.TODO(), &listOptions, machineList)
+		numberOfReadyWorkers = len(readyWorkerNodes)
+		workerNode = &readyWorkerNodes[0]
+		glog.V(2).Infof("Worker node %s", workerNode.Name)
+
+		workerMachine, err = e2e.GetMachineFromNode(client, workerNode)
 		Expect(err).ToNot(HaveOccurred())
-
-		for i, m := range machineList.Items {
-			if m.Status.NodeRef != nil && m.Status.NodeRef.Name == workerNode.Name {
-				workerMachine = &machineList.Items[i]
-				glog.V(2).Infof("Worker machine %s", workerMachine.Name)
-			}
-		}
-		Expect(workerMachine).ToNot(BeNil())
+		glog.V(2).Infof("Worker machine %s", workerMachine.Name)
 
 		glog.V(2).Infof("Create machine health check with label selector: %s", workerMachine.Labels)
 		err = e2e.CreateMachineHealthCheck(workerMachine.Labels)
@@ -176,28 +156,16 @@ func waitForWorkersToGetReady(numberOfReadyWorkers int) {
 	client, err := e2e.LoadClient()
 	Expect(err).ToNot(HaveOccurred())
 
-	listOptions := runtimeclient.ListOptions{
-		Namespace: e2e.TestContext.MachineApiNamespace,
-	}
-	listOptions.SetLabelSelector(fmt.Sprintf("%s=", e2e.NodeWorkerLabel))
-	workers := &corev1.NodeList{}
 	glog.V(2).Infof("Wait until the environment will have %d ready workers", numberOfReadyWorkers)
 	Eventually(func() bool {
-		err := client.List(context.TODO(), &listOptions, workers)
+		workerNodes, err := e2e.GetWorkerNodes(client)
 		if err != nil {
 			return false
 		}
 
-		readyWorkers := 0
-		for _, w := range workers.Items {
-			readyCond := conditions.GetNodeCondition(&w, corev1.NodeReady)
-			if readyCond.Status == corev1.ConditionTrue {
-				readyWorkers++
-			}
-		}
-
-		glog.V(2).Infof("Number of ready workers %d", readyWorkers)
-		return readyWorkers == numberOfReadyWorkers
+		readyWorkerNodes := e2e.FilterReadyNodes(workerNodes)
+		glog.V(2).Infof("Number of ready workers %d", len(readyWorkerNodes))
+		return len(readyWorkerNodes) == numberOfReadyWorkers
 	}, 15*time.Minute, 10*time.Second).Should(BeTrue())
 }
 
@@ -225,7 +193,7 @@ func deleteKubeletKillerPods() {
 	listOptions := runtimeclient.ListOptions{
 		Namespace: e2e.TestContext.MachineApiNamespace,
 	}
-	listOptions.SetLabelSelector(fmt.Sprintf("%s=", e2e.KubeletKillerPodName))
+	listOptions.MatchingLabels(map[string]string{e2e.KubeletKillerPodName: ""})
 	podList := &corev1.PodList{}
 	err = client.List(context.TODO(), &listOptions, podList)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
- move setup logic to separate methods
- add TODO on the kubemark skip condition