### PR TITLE
Wait longer for clusterapi-manager-controllers deployment do re-appear

### DIFF
--- a/pkg/e2e/operators/utils.go
+++ b/pkg/e2e/operators/utils.go
@@ -45,7 +45,7 @@ func deleteDeployment(client runtimeclient.Client, deployment *kappsapi.Deployme
 }
 
 func isDeploymentAvailable(client runtimeclient.Client, name string) bool {
-	if err := wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
+	if err := wait.PollImmediate(1*time.Second, e2e.WaitMedium, func() (bool, error) {
 		d, err := getDeployment(client, name)
 		if err != nil {
 			glog.Errorf("Error getting deployment: %v", err)


### PR DESCRIPTION
Sometimes a clusterapi-manager-controllres-XXXX pod stucks in Terminated
state before a deployment is allowed to be created again. Thus, it takes
longer than 1 minute for a deleted deployment to be re-created by
the machine api operator.