### PR TITLE
e2e/operators/utils: Bump isDeploymentAvailable wait to long

### DIFF
--- a/pkg/e2e/operators/utils.go
+++ b/pkg/e2e/operators/utils.go
@@ -45,7 +45,7 @@ func deleteDeployment(client runtimeclient.Client, deployment *kappsapi.Deployme
 }
 
 func isDeploymentAvailable(client runtimeclient.Client, name string) bool {
-	if err := wait.PollImmediate(1*time.Second, e2e.WaitMedium, func() (bool, error) {
+	if err := wait.PollImmediate(1*time.Second, e2e.WaitLong, func() (bool, error) {
 		d, err := getDeployment(client, name)
 		if err != nil {
 			glog.Errorf("Error getting deployment: %v", err)


### PR DESCRIPTION
This often takes a bit longer than the medium wait time.