### PR TITLE
e2e-aws-operator: Fix machinehealthcheck test

### DIFF
--- a/pkg/e2e/machinehealthcheck/machinehealthcheck.go
+++ b/pkg/e2e/machinehealthcheck/machinehealthcheck.go
@@ -113,8 +113,10 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", f
 		})
 	})
 
-	It("should delete unhealthy machine", func() {
-		stopKubeletAndValidateMachineDeletion(workerNode, workerMachine, 6*time.Minute)
+	Context("without node-unhealthy-conditions configmap", func() {
+		It("should delete unhealthy machine", func() {
+			stopKubeletAndValidateMachineDeletion(workerNode, workerMachine, 7*time.Minute)
+		})
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
In the current test,  [BeforeEach()](https://github.com/openshift/cluster-api-actuator-pkg/blob/master/pkg/e2e/machinehealthcheck/machinehealthcheck.go#L90-#L114) gets executed for [this `It`](https://github.com/openshift/cluster-api-actuator-pkg/blob/master/pkg/e2e/machinehealthcheck/machinehealthcheck.go#L90-#L114). This Before reach deletes configmap as well and when, actually `[stopKubeletAndValidateMachineDeletion](https://github.com/openshift/cluster-api-actuator-pkg/blob/master/pkg/e2e/machinehealthcheck/machinehealthcheck.go#L117)` gets invoked again, there is no configmap and it fails to validate node deletion. And thus test failure!!

I verified this behavior running these tests locally and it occurs every time. 

This PR is simplifying the nesting of BeforeEach and AfterEach. If the intention of the existing changes and this nesting is to execute stopKubeletAndValidateMachineDeletion twice for two machines, we can achieve that by simply copy pasting `IT` block in this PR.