### PR TITLE
Accommodate for new deployment name: machine-api-controllers

### DIFF
--- a/pkg/e2e/operators/machine-api-operator.go
+++ b/pkg/e2e/operators/machine-api-operator.go
@@ -8,6 +8,10 @@ import (
 	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
 )
 
+var (
+	deploymentDeprecatedName = "clusterapi-manager-controllers"
+)
+
 var _ = g.Describe("[Feature:Operators] Machine API operator deployment should", func() {
 	defer g.GinkgoRecover()
 
@@ -23,9 +27,13 @@ var _ = g.Describe("[Feature:Operators] Machine API operator deployment should",
 		client, err := e2e.LoadClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		deploymentName := "clusterapi-manager-controllers"
+		deploymentName := "machine-api-controllers"
 		initialDeployment, err := getDeployment(client, deploymentName)
-		o.Expect(err).NotTo(o.HaveOccurred())
+		if err != nil {
+			initialDeployment, err = getDeployment(client, deploymentDeprecatedName)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			deploymentName = deploymentDeprecatedName
+		}
 
 		g.By(fmt.Sprintf("checking deployment %q is available", deploymentName))
 		o.Expect(isDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
@@ -37,7 +45,6 @@ var _ = g.Describe("[Feature:Operators] Machine API operator deployment should",
 		g.By(fmt.Sprintf("checking deployment %q is available again", deploymentName))
 		o.Expect(isDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
 	})
-
 })
 
 var _ = g.Describe("[Feature:Operators] Machine API cluster operator status should", func() {


### PR DESCRIPTION
Accomodate for better controllers deployment naming https://github.com/openshift/machine-api-operator/pull/278 so it doesn't break the suite in any repo while the payload does not include #278