### PR TITLE
Have ci-integration e2e workdir configurable

### DIFF
--- a/hack/ci-integration.sh
+++ b/hack/ci-integration.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 go test -timeout 90m \
-  -v github.com/openshift/cluster-api-actuator-pkg/pkg/e2e \
+  -v ./pkg/e2e \
   -kubeconfig ${KUBECONFIG:-~/.kube/config} \
   -machine-api-namespace ${NAMESPACE:-openshift-machine-api} \
   -args -v 5 -logtostderr \
-  $@
+  "$@"


### PR DESCRIPTION
So `make test-e2e` can be called over vendor test-suite as well.