### PR TITLE
Introduce a separate target to run tech preview e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,10 @@ test-e2e: ## Run openshift specific e2e test
 	# Feature:Operator tests remove deployments. Thus loosing all the logs
 	# previously acquired.
 	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators"
-	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators"
+	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators|TechPreview"
+
+test-e2e-tech-preview:
+	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "TechPreview"
 
 .PHONY: k8s-e2e
 k8s-e2e: ## Run k8s specific e2e test
@@ -59,7 +62,7 @@ k8s-e2e: ## Run k8s specific e2e test
 	# Feature:Operator tests remove deployments. Thus loosing all the logs
 	# previously acquired.
 	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators"
-	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators"
+	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators|TechPreview"
 
 .PHONY: help
 help:

--- a/pkg/e2e/machinehealthcheck/machinehealthcheck.go
+++ b/pkg/e2e/machinehealthcheck/machinehealthcheck.go
@@ -21,7 +21,7 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", func() {
+var _ = Describe("[TechPreview:Feature:MachineHealthCheck] MachineHealthCheck controller", func() {
 	var client runtimeclient.Client
 	var numberOfReadyWorkers int
 	var workerNode *corev1.Node
@@ -56,10 +56,6 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", f
 		var err error
 		client, err = e2e.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
-
-		// TODO: enable once https://github.com/openshift/cluster-api-actuator-pkg/pull/61 is fixed
-		glog.V(2).Info("Skipping machine health checking test")
-		Skip("Skipping machine health checking test")
 
 		workerNodes, err := e2e.GetWorkerNodes(client)
 		Expect(err).ToNot(HaveOccurred())
@@ -112,10 +108,6 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", f
 	})
 
 	AfterEach(func() {
-		// TODO: enable once https://github.com/openshift/cluster-api-actuator-pkg/pull/61 is fixed
-		glog.V(2).Info("Skipping machine health checking test")
-		Skip("Skipping machine health checking test")
-
 		waitForWorkersToGetReady(numberOfReadyWorkers)
 		deleteMachineHealthCheck(e2e.MachineHealthCheckName)
 		deleteKubeletKillerPods()


### PR DESCRIPTION
- create separate make target for tech preview e2e tests
- skip tech preview tests under the test-e2e target
- skip tech preview tests under the k8s-e2e target