### PR TITLE
e2e: create required MachineSets as part of test setup

### DIFF
--- a/pkg/e2e/autoscaler/autoscaler.go
+++ b/pkg/e2e/autoscaler/autoscaler.go
@@ -11,6 +11,7 @@ import (
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
+	"github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra"
 	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	caov1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
 	caov1beta1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1"
@@ -261,16 +262,82 @@ var _ = g.Describe("[Feature:Machines][Serial] Autoscaler should", func() {
 			}
 		}()
 
-		g.By("Getting machinesets")
-		machineSets, err := e2e.GetMachineSets(context.TODO(), client)
+		g.By("Getting existing machinesets")
+		existingMachineSets, err := e2e.GetMachineSets(context.TODO(), client)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(len(machineSets)).To(o.BeNumerically(">=", 2))
+		o.Expect(len(existingMachineSets)).To(o.BeNumerically(">=", 1))
 
-		g.By("Getting machines")
-		machines, err := e2e.GetMachines(context.TODO(), client)
+		g.By("Getting existing machines")
+		existingMachines, err := e2e.GetMachines(context.TODO(), client)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(len(machines)).To(o.BeNumerically(">=", 1))
+		o.Expect(len(existingMachines)).To(o.BeNumerically(">=", 1))
 
+		g.By("Getting existing nodes")
+		existingNodes, err := e2e.GetNodes(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(existingNodes)).To(o.BeNumerically(">=", 1))
+
+		glog.Infof("Have %v existing machinesets", len(existingMachineSets))
+		glog.Infof("Have %v existing machines", len(existingMachines))
+		glog.Infof("Have %v existing nodes", len(existingNodes))
+
+		for i := 0; i < len(existingMachineSets); i++ {
+			// If we have existing machineset's then we're
+			// going to utilize those machines/nodes for
+			// autoscaling so they must be Ready to scale.
+			o.Expect(existingMachineSets[i].Status.ReadyReplicas).To(o.BeNumerically(">=", 1))
+		}
+
+		// The remainder of the logic in this test requires 3
+		// machinesets.
+		var machineSets [3]*mapiv1beta1.MachineSet
+
+		// reuse machinesets that already exist, but no more than 3
+		for i := 0; i < len(existingMachineSets); i++ {
+			if i == len(machineSets) {
+				break
+			}
+			machineSets[i] = existingMachineSets[i].DeepCopy()
+		}
+
+		// create new machinesets so that we have 3
+		for i := len(existingMachineSets); i < len(machineSets); i++ {
+			targetMachineSet := existingMachineSets[i%len(existingMachineSets)]
+			machineSetName := fmt.Sprintf("autoscaler-e2e-%d-%s", i, targetMachineSet.Name)
+			machineSets[i] = e2e.NewMachineSet(targetMachineSet.Labels[e2e.ClusterKey],
+				targetMachineSet.Namespace,
+				machineSetName,
+				targetMachineSet.Spec.Selector.MatchLabels,
+				targetMachineSet.Spec.Template.ObjectMeta.Labels,
+				&targetMachineSet.Spec.Template.Spec.ProviderSpec,
+				1) // one replica
+			machineSets[i].Spec.Template.Spec.ObjectMeta.Labels = map[string]string{
+				e2e.WorkerNodeRoleLabel: "",
+			}
+			o.Expect(client.Create(context.TODO(), machineSets[i])).Should(o.Succeed())
+			cleanupObjects = append(cleanupObjects, runtime.Object(machineSets[i]))
+		}
+
+		if additionalMachineSets := len(machineSets) - len(existingMachineSets); additionalMachineSets > 0 {
+			g.By(fmt.Sprintf("Creating %v transient machinesets", additionalMachineSets))
+			testDuration := time.Now().Add(time.Duration(e2e.WaitLong))
+			o.Eventually(func() bool {
+				g.By(fmt.Sprintf("[%s remaining] Waiting for nodes to be Ready in %v transient machinesets",
+					remaining(testDuration), additionalMachineSets))
+				var allNewNodes []*corev1.Node
+				for i := len(existingMachineSets); i < len(machineSets); i++ {
+					nodes, err := infra.GetNodesFromMachineSet(client, *machineSets[i])
+					if err != nil {
+						return false
+					}
+					allNewNodes = append(allNewNodes, nodes...)
+				}
+				return len(allNewNodes) == additionalMachineSets && infra.NodesAreReady(allNewNodes)
+			}, e2e.WaitLong, pollingInterval).Should(o.BeTrue())
+		}
+
+		// Now that we have created some transient machinesets
+		// take stock of the number of nodes we now have.
 		g.By("Getting nodes")
 		nodes, err := e2e.GetNodes(client)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -279,15 +346,9 @@ var _ = g.Describe("[Feature:Machines][Serial] Autoscaler should", func() {
 		g.By(fmt.Sprintf("Creating %v machineautoscalers", len(machineSets)))
 		var clusterExpansionSize int
 		for i := range machineSets {
-			min := pointer.Int32PtrDerefOr(machineSets[i].Spec.Replicas, 1)
-			// We only want each machineautoscaler
-			// resource to be able to grow by one
-			// additional node.
-			max := min + 1
 			clusterExpansionSize += 1
-
-			glog.Infof("Create MachineAutoscaler backed by MachineSet %s/%s - min:%v, max:%v", machineSets[i].Namespace, machineSets[i].Name, min, max)
-			asr := machineAutoscalerResource(&machineSets[i], min, max)
+			glog.Infof("Create MachineAutoscaler backed by MachineSet %s/%s - min:%v, max:%v", machineSets[i].Namespace, machineSets[i].Name, 1, 2)
+			asr := machineAutoscalerResource(machineSets[i], 1, 2)
 			o.Expect(client.Create(context.TODO(), asr)).Should(o.Succeed())
 			cleanupObjects = append(cleanupObjects, runtime.Object(asr))
 		}
@@ -348,7 +409,7 @@ var _ = g.Describe("[Feature:Machines][Serial] Autoscaler should", func() {
 			glog.Infof("[%s remaining] Waiting for %s to generate a %q event; observed %v",
 				remaining(testDuration), clusterAutoscalerComponent, clusterAutoscalerMaxNodesTotalReached, v)
 			return v
-		}, e2e.WaitShort, 3*time.Second).Should(o.BeNumerically(">=", 1))
+		}, e2e.WaitShort, pollingInterval).Should(o.BeNumerically(">=", 1))
 
 		testDuration = time.Now().Add(time.Duration(e2e.WaitShort))
 		o.Consistently(func() bool {
@@ -372,24 +433,34 @@ var _ = g.Describe("[Feature:Machines][Serial] Autoscaler should", func() {
 			return v
 		}, e2e.WaitLong, pollingInterval).Should(o.BeZero())
 
+		g.By("Scaling transient machinesets to zero")
+		for i := len(existingMachineSets); i < len(machineSets); i++ {
+			glog.Infof("Scaling transient machineset %q to zero", machineSets[i].Name)
+			freshMachineSet, err := e2e.GetMachineSet(context.TODO(), client, machineSets[i].Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			freshMachineSet.Spec.Replicas = pointer.Int32Ptr(0)
+			err = client.Update(context.TODO(), freshMachineSet)
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}
+
 		g.By("Waiting for scaled up nodes to be deleted")
 		testDuration = time.Now().Add(time.Duration(e2e.WaitMedium))
 		o.Eventually(func() int {
 			currentNodes, err := e2e.GetNodes(client)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			glog.Infof("[%s remaining] Waiting fo cluster to reach original node count of %v; currently have %v",
-				remaining(testDuration), len(nodes), len(currentNodes))
+			glog.Infof("[%s remaining] Waiting for cluster to reach original node count of %v; currently have %v",
+				remaining(testDuration), len(existingNodes), len(currentNodes))
 			return len(currentNodes)
-		}, e2e.WaitMedium, pollingInterval).Should(o.Equal(len(nodes)))
+		}, e2e.WaitMedium, pollingInterval).Should(o.Equal(len(existingNodes)))
 
 		g.By("Waiting for scaled up machines to be deleted")
 		testDuration = time.Now().Add(time.Duration(e2e.WaitMedium))
 		o.Eventually(func() int {
 			currentMachines, err := e2e.GetMachines(context.TODO(), client)
 			o.Expect(err).NotTo(o.HaveOccurred())
-			glog.Infof("[%s remaining] Waiting fo cluster to reach original machine count of %v; currently have %v",
-				remaining(testDuration), len(machines), len(currentMachines))
+			glog.Infof("[%s remaining] Waiting for cluster to reach original machine count of %v; currently have %v",
+				remaining(testDuration), len(existingMachines), len(currentMachines))
 			return len(currentMachines)
-		}, e2e.WaitMedium, pollingInterval).Should(o.Equal(len(machines)))
+		}, e2e.WaitMedium, pollingInterval).Should(o.Equal(len(existingMachines)))
 	})
 })

--- a/pkg/e2e/framework/common.go
+++ b/pkg/e2e/framework/common.go
@@ -18,8 +18,8 @@ import (
 const (
 	WorkerNodeRoleLabel = "node-role.kubernetes.io/worker"
 	WaitShort           = 1 * time.Minute
-	WaitMedium          = 3 * time.Minute
-	WaitLong            = 10 * time.Minute
+	WaitMedium          = 9 * time.Minute
+	WaitLong            = 20 * time.Minute
 	RetryMedium         = 5 * time.Second
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil

--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -324,19 +324,19 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		o.Eventually(func() bool {
-			nodes, err := getNodesFromMachineSet(client, machineSet0)
+			nodes, err := GetNodesFromMachineSet(client, machineSet0)
 			if err != nil {
 				return false
 			}
-			return len(nodes) == scaleOut && nodesAreReady(nodes)
+			return len(nodes) == scaleOut && NodesAreReady(nodes)
 		}, e2e.WaitLong, 5*time.Second).Should(o.BeTrue())
 
 		o.Eventually(func() bool {
-			nodes, err := getNodesFromMachineSet(client, machineSet1)
+			nodes, err := GetNodesFromMachineSet(client, machineSet1)
 			if err != nil {
 				return false
 			}
-			return len(nodes) == scaleOut && nodesAreReady(nodes)
+			return len(nodes) == scaleOut && NodesAreReady(nodes)
 		}, e2e.WaitLong, 5*time.Second).Should(o.BeTrue())
 
 		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSet0.Name, scaleOut, initialReplicasMachineSet0))

--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/pointer"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -258,97 +257,88 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("grow or decrease when scaling out or in", func() {
-		g.By("checking initial cluster state")
-		client, err := e2e.LoadClient()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		initialClusterSize, err := getClusterSize(client)
-		err = waitForClusterSizeToBeHealthy(client, initialClusterSize)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		machineSets, err := e2e.GetMachineSets(context.TODO(), client)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(len(machineSets)).To(o.BeNumerically(">=", 2))
-		machineSet := machineSets[0]
-		initialReplicasMachineSet := int(pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, e2e.DefaultMachineSetReplicas))
-		scaleOut := 3
-		scaleIn := initialReplicasMachineSet
-		originalReplicas := initialReplicasMachineSet
-		clusterGrowth := scaleOut - originalReplicas
-		clusterDecrease := scaleOut - scaleIn
-		intermediateClusterSize := initialClusterSize + clusterGrowth
-		finalClusterSize := initialClusterSize + clusterGrowth - clusterDecrease
-
-		g.By(fmt.Sprintf("scaling out %q machineSet to %d replicas", machineSet.Name, scaleOut))
-		err = scaleMachineSet(machineSet.Name, scaleOut)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By(fmt.Sprintf("waiting for cluster to grow %d nodes. Size should be %d", clusterGrowth, intermediateClusterSize))
-		err = waitForClusterSizeToBeHealthy(client, intermediateClusterSize)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By(fmt.Sprintf("scaling in %q machineSet to %d replicas", machineSet.Name, scaleIn))
-		err = scaleMachineSet(machineSet.Name, scaleIn)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By(fmt.Sprintf("waiting for cluster to decrease %d nodes. Final size should be %d nodes", clusterDecrease, finalClusterSize))
-		err = waitForClusterSizeToBeHealthy(client, finalClusterSize)
-		o.Expect(err).NotTo(o.HaveOccurred())
-	})
-
 	g.It("grow and decrease when scaling different machineSets simultaneously", func() {
 		client, err := e2e.LoadClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		scaleOut := 3
+		scaleOut := 2
 
-		g.By("checking initial cluster size")
-		initialClusterSize, err := getClusterSize(client)
+		deleteObject := func(obj runtime.Object) error {
+			return client.Delete(context.TODO(), obj, func(opt *runtimeclient.DeleteOptions) {
+				cascadeDelete := metav1.DeletePropagationForeground
+				opt.PropagationPolicy = &cascadeDelete
+			})
+		}
+
+		// Anything we create we must cleanup
+		var cleanupObjects []runtime.Object
+		defer func() {
+			for _, obj := range cleanupObjects {
+				if err := deleteObject(obj); err != nil {
+					glog.Errorf("[cleanup] error deleting object: %v", err)
+				}
+			}
+		}()
+
+		g.By("checking existing cluster size")
+		existingClusterSize, err := getClusterSize(client)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("getting worker machineSets")
-		machineSets, err := e2e.GetMachineSets(context.TODO(), client)
+		existingMachineSets, err := e2e.GetMachineSets(context.TODO(), client)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(len(machineSets)).To(o.BeNumerically(">=", 2))
-		machineSet0 := machineSets[0]
-		initialReplicasMachineSet0 := int(pointer.Int32PtrDerefOr(machineSet0.Spec.Replicas, e2e.DefaultMachineSetReplicas))
-		machineSet1 := machineSets[1]
-		initialReplicasMachineSet1 := int(pointer.Int32PtrDerefOr(machineSet1.Spec.Replicas, e2e.DefaultMachineSetReplicas))
+		o.Expect(len(existingMachineSets)).To(o.BeNumerically(">=", 1))
 
-		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSet0.Name, initialReplicasMachineSet0, scaleOut))
-		err = scaleMachineSet(machineSet0.Name, scaleOut)
+		// Create transient machinesets with replicas==0
+		machineSets := make([]*mapiv1beta1.MachineSet, scaleOut)
+		for i := 0; i < scaleOut; i++ {
+			targetMachineSet := existingMachineSets[i%len(existingMachineSets)]
+			machineSetName := fmt.Sprintf("infra-e2e-%d-%s", i, targetMachineSet.Name)
+			glog.Infof("Creating transient MachineSet %q", machineSetName)
+			machineSets[i] = e2e.NewMachineSet(
+				targetMachineSet.Labels[e2e.ClusterKey],
+				targetMachineSet.Namespace,
+				machineSetName,
+				targetMachineSet.Spec.Selector.MatchLabels,
+				targetMachineSet.Spec.Template.ObjectMeta.Labels,
+				&targetMachineSet.Spec.Template.Spec.ProviderSpec,
+				0) // zero replicas
+			machineSets[i].Spec.Template.Spec.ObjectMeta.Labels = map[string]string{
+				e2e.WorkerNodeRoleLabel: "",
+			}
+			o.Expect(client.Create(context.TODO(), machineSets[i])).Should(o.Succeed())
+			cleanupObjects = append(cleanupObjects, runtime.Object(machineSets[i]))
+		}
+
+		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSets[0].Name, 0, scaleOut))
+		err = scaleMachineSet(machineSets[0].Name, scaleOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSet1.Name, initialReplicasMachineSet1, scaleOut))
-		err = scaleMachineSet(machineSet1.Name, scaleOut)
+		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSets[1].Name, 0, scaleOut))
+		err = scaleMachineSet(machineSets[1].Name, scaleOut)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		o.Eventually(func() bool {
-			nodes, err := GetNodesFromMachineSet(client, machineSet0)
+			nodes0, err := GetNodesFromMachineSet(client, *machineSets[0])
 			if err != nil {
 				return false
 			}
-			return len(nodes) == scaleOut && NodesAreReady(nodes)
-		}, e2e.WaitLong, 5*time.Second).Should(o.BeTrue())
-
-		o.Eventually(func() bool {
-			nodes, err := GetNodesFromMachineSet(client, machineSet1)
+			nodes1, err := GetNodesFromMachineSet(client, *machineSets[1])
 			if err != nil {
 				return false
 			}
-			return len(nodes) == scaleOut && NodesAreReady(nodes)
+			return len(nodes0) == scaleOut && NodesAreReady(nodes0) && len(nodes1) == scaleOut && NodesAreReady(nodes1)
 		}, e2e.WaitLong, 5*time.Second).Should(o.BeTrue())
 
-		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSet0.Name, scaleOut, initialReplicasMachineSet0))
-		err = scaleMachineSet(machineSet0.Name, initialReplicasMachineSet0)
+		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSets[0].Name, scaleOut, 0))
+		err = scaleMachineSet(machineSets[0].Name, 0)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSet1.Name, scaleOut, initialReplicasMachineSet1))
-		err = scaleMachineSet(machineSet1.Name, initialReplicasMachineSet1)
+		g.By(fmt.Sprintf("scaling %q from %d to %d replicas", machineSets[1].Name, scaleOut, 0))
+		err = scaleMachineSet(machineSets[1].Name, 0)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By(fmt.Sprintf("waiting for cluster to get back to original size. Final size should be %d nodes", initialClusterSize))
-		err = waitForClusterSizeToBeHealthy(client, initialClusterSize)
+		g.By(fmt.Sprintf("waiting for cluster to get back to original size. Final size should be %d nodes", existingClusterSize))
+		err = waitForClusterSizeToBeHealthy(client, existingClusterSize)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/pkg/e2e/infra/utils.go
+++ b/pkg/e2e/infra/utils.go
@@ -130,8 +130,8 @@ func deleteMachine(client runtimeclient.Client, machine *mapiv1beta1.Machine) er
 	})
 }
 
-// getNodesFromMachineSet returns an array of nodes backed by machines owned by a given machineSet
-func getNodesFromMachineSet(client runtimeclient.Client, machineSet mapiv1beta1.MachineSet) ([]*corev1.Node, error) {
+// GetNodesFromMachineSet returns an array of nodes backed by machines owned by a given machineSet
+func GetNodesFromMachineSet(client runtimeclient.Client, machineSet mapiv1beta1.MachineSet) ([]*corev1.Node, error) {
 	machines, err := getMachinesFromMachineSet(client, machineSet)
 	if err != nil {
 		return nil, fmt.Errorf("error calling getMachinesFromMachineSet %v", err)
@@ -165,8 +165,8 @@ func getNodeFromMachine(client runtimeclient.Client, machine *mapiv1beta1.Machin
 	return &node, nil
 }
 
-// nodesAreReady returns true if an array of nodes are all ready
-func nodesAreReady(nodes []*corev1.Node) bool {
+// NodesAreReady returns true if an array of nodes are all ready
+func NodesAreReady(nodes []*corev1.Node) bool {
 	// All nodes needs to be ready
 	for key := range nodes {
 		if !e2e.IsNodeReady(nodes[key]) {


### PR DESCRIPTION
Rather than use the MachineSet's that may (or may not) come with the
installed platform we now create the number of MachineSet's we
actually need as part of test setup; on AWS we get three and on Azure
we currently get one. To handle these kind of differences this commit
changes the autoscaler and infra tests to create what it needs as part
of test setup.

The new setup requires at least one MachineSet with an accompanying
Node to be present. From that MachineSet we create the missing
MachineSet's - solely for autoscaler testing. Labels and the
ProviderSpec are propagated to the new MachineSet's from the first
MachineSet discovered on the cluster.
