### PR TITLE
Reduce timeouts back to their previous default pre-Azure

### DIFF
--- a/pkg/e2e/autoscaler/autoscaler.go
+++ b/pkg/e2e/autoscaler/autoscaler.go
@@ -454,13 +454,13 @@ var _ = g.Describe("[Feature:Machines][Serial] Autoscaler should", func() {
 		}, e2e.WaitMedium, pollingInterval).Should(o.Equal(len(existingNodes)))
 
 		g.By("Waiting for scaled up machines to be deleted")
-		testDuration = time.Now().Add(time.Duration(e2e.WaitMedium))
+		testDuration = time.Now().Add(time.Duration(e2e.WaitLong))
 		o.Eventually(func() int {
 			currentMachines, err := e2e.GetMachines(context.TODO(), client)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			glog.Infof("[%s remaining] Waiting for cluster to reach original machine count of %v; currently have %v",
 				remaining(testDuration), len(existingMachines), len(currentMachines))
 			return len(currentMachines)
-		}, e2e.WaitMedium, pollingInterval).Should(o.Equal(len(existingMachines)))
+		}, e2e.WaitLong, pollingInterval).Should(o.Equal(len(existingMachines)))
 	})
 })

--- a/pkg/e2e/framework/common.go
+++ b/pkg/e2e/framework/common.go
@@ -18,8 +18,8 @@ import (
 const (
 	WorkerNodeRoleLabel = "node-role.kubernetes.io/worker"
 	WaitShort           = 1 * time.Minute
-	WaitMedium          = 9 * time.Minute
-	WaitLong            = 20 * time.Minute
+	WaitMedium          = 3 * time.Minute
+	WaitLong            = 10 * time.Minute
 	RetryMedium         = 5 * time.Second
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil


### PR DESCRIPTION
This reverts the commit (in PR #96) that globally bumped the test timeouts. The intent in that PR was to make e2e run to completion on Azure. As some of the e2e x Azure issues have stabilised this reverts the global timeout changes but bumps localised cases in the autoscaler tests when scaling down. Nodes simply take longer to delete on Azure right now.