### PR TITLE
e2e/framework: Bump WaitLong from 10m to 15m

### DIFF
--- a/pkg/e2e/framework/common.go
+++ b/pkg/e2e/framework/common.go
@@ -19,7 +19,7 @@ const (
 	WorkerNodeRoleLabel = "node-role.kubernetes.io/worker"
 	WaitShort           = 1 * time.Minute
 	WaitMedium          = 3 * time.Minute
-	WaitLong            = 10 * time.Minute
+	WaitLong            = 15 * time.Minute
 	RetryMedium         = 5 * time.Second
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil


### PR DESCRIPTION
As e2e tests are flaking/failing because their timeout is exceeded,
increasing `WaitLong` from 10min to 15min.

```console
I0807 04:10:42.570984    7150 utils.go:398] [0s remaining] Waiting for RC ready replicas, ReadyReplicas: 17, Replicas: 20
```