### PR TITLE
Makefile: ensure e2e/autoscaler tests run first in test-e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ test-e2e: ## Run openshift specific e2e test
 	# failures and flakes.
 	# Feature:Operator tests remove deployments. Thus loosing all the logs
 	# previously acquired.
-	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators" -ginkgo.failFast
-	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators|TechPreview" -ginkgo.failFast
+	hack/ci-integration.sh $(GINKGO_ARGS) -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators" -ginkgo.failFast
+	hack/ci-integration.sh $(GINKGO_ARGS) -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators|TechPreview" -ginkgo.failFast -ginkgo.seed=1
 
 test-e2e-tech-preview:
-	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "TechPreview" -ginkgo.failFast
+	hack/ci-integration.sh $(GINKGO_ARGS) -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "TechPreview" -ginkgo.failFast
 
 .PHONY: k8s-e2e
 k8s-e2e: ## Run k8s specific e2e test
@@ -73,8 +73,8 @@ k8s-e2e: ## Run k8s specific e2e test
 	# failures and flakes.
 	# Feature:Operator tests remove deployments. Thus loosing all the logs
 	# previously acquired.
-	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators" -ginkgo.failFast
-	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators|TechPreview" -ginkgo.failFast
+	NAMESPACE=kube-system hack/ci-integration.sh $(GINKGO_ARGS) -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators" -ginkgo.failFast
+	NAMESPACE=kube-system hack/ci-integration.sh $(GINKGO_ARGS) -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators|TechPreview" -ginkgo.failFast -ginkgo.seed=1
 
 .PHONY: help
 help:

--- a/pkg/e2e/autoscaler/autoscaler.go
+++ b/pkg/e2e/autoscaler/autoscaler.go
@@ -226,7 +226,7 @@ func dumpClusterAutoscalerLogs(client runtimeclient.Client, restClient *rest.RES
 	}
 }
 
-var _ = g.Describe("[Feature:Machines][Serial] Autoscaler should", func() {
+var _ = g.Describe("[Feature:Machines] Autoscaler should", func() {
 	g.It("scale up and down", func() {
 		defer g.GinkgoRecover()
 


### PR DESCRIPTION
The autoscaler tests are most susceptible to the current state of the
cluster when they start running. If previous tests don't clean up
properly then we end up with additional nodes that will be used for
scheduling and that will break the expectations in the e2e/autoscaler
specs.

To mitigate the randomized ordering we now run the autoscaler tests
first by always specifying the _same_ seed value (so no more
randomized testing). It just so happens (I suspect) that "Autoscaler"
is now listed first due to sorting/collating. We should be wary of
this when adding new specs.

We will revisit this change once we have made further progress with
general test cleanup, particularly on any failure. Flaking on the
autoscaler tests is currently very costly as we have pushed out gating
time to 1h 45m (sob).

Also added $(GINKGO_ARGS) so that you can do the following:

    $ GINKGO_ARGS=-ginkgo.dryRun make test-e2e

```console
hack/ci-integration.sh -ginkgo.dryRun -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators|TechPreview" -ginkgo.seed=1
=== RUN   TestE2E
Running Suite: Machine Suite
============================
Random Seed: 1
Will run 7 of 16 specs

SSSSSSSS
------------------------------
[Feature:Machines] Autoscaler should
  scale up and down
  /home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/autoscaler/autoscaler.go:230
•S
------------------------------
[Feature:Machines] Managed cluster should
  have machines linked with nodes
  /home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go:136
•
------------------------------
[Feature:Machines] Managed cluster should
  have ability to additively reconcile taints from machine to nodes
  /home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go:145
•
------------------------------
[Feature:Machines] Managed cluster should
  recover from deleted worker machines
  /home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go:220
•
------------------------------
[Feature:Machines] Managed cluster should
  grow and decrease when scaling different machineSets simultaneously
  /home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go:267
•
------------------------------
[Feature:Machines] Managed cluster should
  drain node before removing machine resource
  /home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go:345
•
------------------------------
[Feature:Machines] Managed cluster should
  reject invalid machinesets
  /home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go:486
•
Ran 7 of 16 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 9 Skipped
--- PASS: TestE2E (0.00s)
PASS
ok  	github.com/openshift/cluster-api-actuator-pkg/pkg/e2e	0.034s
```