### PR TITLE
Use smaller names when creating transient MachineSets

### DIFF
--- a/pkg/e2e/autoscaler/autoscaler.go
+++ b/pkg/e2e/autoscaler/autoscaler.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -287,9 +288,10 @@ var _ = g.Describe("[Feature:Machines] Autoscaler should", func() {
 		// machinesets.
 		var machineSets [3]*mapiv1beta1.MachineSet
 
+		randomUUID := string(uuid.NewUUID())
 		for i := 0; i < len(machineSets); i++ {
 			targetMachineSet := existingMachineSets[i%len(existingMachineSets)]
-			machineSetName := fmt.Sprintf("autoscaler-e2e-%d-%s", i, targetMachineSet.Name)
+			machineSetName := fmt.Sprintf("e2e-%s-w-%d", randomUUID[:5], i)
 			machineSets[i] = e2e.NewMachineSet(targetMachineSet.Labels[e2e.ClusterKey],
 				targetMachineSet.Namespace,
 				machineSetName,

--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -290,9 +290,10 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 
 		// Create transient machinesets with replicas==0
 		machineSets := make([]*mapiv1beta1.MachineSet, scaleOut)
+		randomUUID := string(uuid.NewUUID())
 		for i := 0; i < scaleOut; i++ {
 			targetMachineSet := existingMachineSets[i%len(existingMachineSets)]
-			machineSetName := fmt.Sprintf("infra-e2e-%d-%s", i, targetMachineSet.Name)
+			machineSetName := fmt.Sprintf("e2e-%s-w-%d", randomUUID[:5], i)
 			glog.Infof("Creating transient MachineSet %q", machineSetName)
 			machineSets[i] = e2e.NewMachineSet(
 				targetMachineSet.Labels[e2e.ClusterKey],


### PR DESCRIPTION
The combination of the MachineSet and Machine Name were busting GCP
limits for resource names which must be 1-63 characters in length[1].

I have manually tested the two cases where we using this auto
generated names and both cases now pass.

```console
• [SLOW TEST:737.138 seconds]
[Feature:Machines] Autoscaler should
/home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/autoscaler/autoscaler.go:231
  scale up and down
  /home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/autoscaler/autoscaler.go:232
------------------------------
SSSSS
Ran 1 of 16 Specs in 737.139 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 15 Skipped
PASS
```

```console
• [SLOW TEST:502.141 seconds]
[Feature:Machines] Managed cluster should
/home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go:126
  grow and decrease when scaling different machineSets simultaneously
  /home/aim/go-projects/cluster-api-actuator-pkg/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra/infra.go:267
------------------------------
SS
Ran 1 of 16 Specs in 502.141 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 15 Skipped
PASS
```

[1] https://cloud.google.com/compute/docs/reference/rest/v1/instances/get