### PR TITLE
Wait for a drained node to be deleted a bit longer (1m -> 3m)

### DIFF
--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -452,7 +452,7 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Validating the machine is deleted")
-		err = wait.PollImmediate(e2e.RetryMedium, e2e.WaitShort, func() (bool, error) {
+		err = wait.PollImmediate(e2e.RetryMedium, e2e.WaitMedium, func() (bool, error) {
 			machine := mapiv1beta1.Machine{}
 
 			key := types.NamespacedName{


### PR DESCRIPTION
Wait for a drained node to be deleted a bit longer (1m -> 3m)
    
Otherwise, the draining test is failing:
    
```
I0917 09:36:16.493790       1 controller.go:227] Machine "machine1" deletion successful
```
    
```
E0917 09:35:39.750590    6102 infra.go:464] Machine "machine1" not yet deleted
I0917 09:35:39.750938    6102 infra.go:365] Deleting object "pdb"
```
    
The machine deletion took 37s longer.