### PR TITLE
e2e: Add MachineHealthCheck tests for v1beta1

### DIFF
--- a/pkg/e2e/e2e_test.go
+++ b/pkg/e2e/e2e_test.go
@@ -15,6 +15,7 @@ import (
 
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/autoscaler"
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra"
+	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/machinehealthcheck"
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators"
 )
 

--- a/pkg/e2e/framework/common.go
+++ b/pkg/e2e/framework/common.go
@@ -5,13 +5,18 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/gomega"
+
 	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	caov1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
 	caov1beta1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -24,6 +29,10 @@ const (
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil
 	DefaultMachineSetReplicas = 0
+
+	MachinePhaseRunning = "Running"
+	MachineRoleLabel    = "machine.openshift.io/cluster-api-machine-role"
+	MachineTypeLabel    = "machine.openshift.io/cluster-api-machine-type"
 )
 
 // GetNodes gets a list of nodes from a running cluster
@@ -163,4 +172,188 @@ func DeleteObjectsByLabels(ctx context.Context, client runtimeclient.Client, lab
 	}
 
 	return nil
+}
+
+// FilterRunningMachines returns a slice of only those Machines in the input
+// that are in the "Running" phase.
+func FilterRunningMachines(machines []mapiv1beta1.Machine) []*mapiv1beta1.Machine {
+	// TODO(bison): This function should probably take a slice of pointers, but
+	// GetMachines() doesn't return that for whatever reason now.
+	var result []*mapiv1beta1.Machine
+
+	for i, m := range machines {
+		if m.Status.Phase != nil && *m.Status.Phase == MachinePhaseRunning {
+			result = append(result, &machines[i])
+		}
+	}
+
+	return result
+}
+
+// GetWorkerMachineSets returns the MachineSets that label their Machines with
+// the "worker" role.
+func GetWorkerMachineSets(c client.Client) ([]*mapiv1beta1.MachineSet, error) {
+	machineSets := &mapiv1beta1.MachineSetList{}
+
+	if err := c.List(context.Background(), machineSets); err != nil {
+		return nil, err
+	}
+
+	var result []*mapiv1beta1.MachineSet
+
+	// The OpenShift installer does not label MachinSets with a type or role,
+	// but the Machines themselves are labled as such via the template., so we
+	// can reach into the template and check the lables there.
+	for i, ms := range machineSets.Items {
+		labels := ms.Spec.Template.GetLabels()
+
+		if labels[MachineRoleLabel] == "worker" {
+			result = append(result, &machineSets.Items[i])
+		}
+	}
+
+	if len(result) < 1 {
+		return nil, fmt.Errorf("no worker MachineSets found")
+	}
+
+	return result, nil
+}
+
+// MachineSetParams represents the parameters for creating a new MachineSet
+// resource for use in tests.
+type MachineSetParams struct {
+	Name         string
+	Replicas     int32
+	Labels       map[string]string
+	ProviderSpec *mapiv1beta1.ProviderSpec
+}
+
+// CreateMachineSet creates a new MachineSet resource.
+func CreateMachineSet(c client.Client, params MachineSetParams) (*mapiv1beta1.MachineSet, error) {
+	if params.Labels == nil {
+		params.Labels = make(map[string]string)
+	}
+
+	// TODO(bison): It would be nice to automatically set the Cluster ID / name
+	// in the labels here, but I'm not sure how to easily find it.
+	params.Labels["e2e.openshift.io"] =
+		fmt.Sprintf("%s-%d", params.Name, time.Now().Unix())
+
+	ms := &mapiv1beta1.MachineSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachineSet",
+			APIVersion: "machine.openshift.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.Name,
+			Namespace: TestContext.MachineApiNamespace,
+			Labels:    params.Labels,
+		},
+		Spec: mapiv1beta1.MachineSetSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: params.Labels,
+			},
+			Template: mapiv1beta1.MachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: params.Labels,
+				},
+				Spec: mapiv1beta1.MachineSpec{
+					ProviderSpec: *params.ProviderSpec,
+				},
+			},
+			Replicas: pointer.Int32Ptr(params.Replicas),
+		},
+	}
+
+	if err := c.Create(context.Background(), ms); err != nil {
+		return nil, err
+	}
+
+	return ms, nil
+}
+
+// WaitForMachineSet waits for the all Machines belonging to the named
+// MachineSet to enter the "Running" phase, and for all nodes belonging to those
+// Machines to be ready.
+func WaitForMachineSet(c client.Client, name string) {
+	machineSet, err := GetMachineSet(context.Background(), c, name)
+	Expect(err).ToNot(HaveOccurred())
+
+	selector := machineSet.Spec.Selector
+
+	Eventually(func() error {
+		machines, err := GetMachines(context.Background(), c, &selector)
+		if err != nil {
+			return err
+		}
+
+		replicas := pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, 0)
+
+		if len(machines) != int(replicas) {
+			return fmt.Errorf("found %d Machines, but MachineSet has %d replicas",
+				len(machines), machineSet.Spec.Replicas)
+		}
+
+		running := FilterRunningMachines(machines)
+
+		// This could probably be smarter, but seems fine for now.
+		if len(running) != len(machines) {
+			return fmt.Errorf("not all Machines are running")
+		}
+
+		for _, m := range running {
+			node, err := GetNodeForMachine(c, m)
+			if err != nil {
+				return err
+			}
+
+			if !IsNodeReady(node) {
+				return fmt.Errorf("%s: node is not ready", node.Name)
+			}
+		}
+
+		return nil
+	}, WaitLong, RetryMedium).ShouldNot(HaveOccurred())
+}
+
+// WaitForMachineSetDelete polls until the given MachineSet is not found, and
+// there are zero Machines found matching the MachineSet's label selector.
+func WaitForMachineSetDelete(c client.Client, machineSet *mapiv1beta1.MachineSet) {
+	Eventually(func() bool {
+		selector := machineSet.Spec.Selector
+
+		machines, err := GetMachines(context.Background(), c, &selector)
+		if err != nil || len(machines) != 0 {
+			return false // Still have Machines, or other error.
+		}
+
+		err = c.Get(context.Background(), client.ObjectKey{
+			Name:      machineSet.GetName(),
+			Namespace: machineSet.GetNamespace(),
+		}, &mapiv1beta1.MachineSet{})
+
+		if !apierrors.IsNotFound(err) {
+			return false // MachineSet not deleted, or other error.
+		}
+
+		return true // MachineSet and Machines were deleted.
+	}, WaitLong, RetryMedium).Should(BeTrue())
+}
+
+// WaitForMachineDelete polls until the given Machines are not found.
+func WaitForMachineDelete(c client.Client, machines ...*mapiv1beta1.Machine) {
+	Eventually(func() bool {
+		for _, m := range machines {
+			err := c.Get(context.Background(), client.ObjectKey{
+				Name:      m.GetName(),
+				Namespace: m.GetNamespace(),
+			}, &mapiv1beta1.Machine{})
+
+			if !apierrors.IsNotFound(err) {
+				return false // Not deleted, or other error.
+			}
+		}
+
+		return true // Everything was deleted.
+	}, WaitLong, RetryMedium).Should(BeTrue())
 }

--- a/pkg/e2e/framework/machinehealthcheck.go
+++ b/pkg/e2e/framework/machinehealthcheck.go
@@ -1,0 +1,50 @@
+package framework
+
+import (
+	"context"
+
+	mhcv1beta1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MachineHealthCheckParams represents the parameters for creating a
+// new MachineHealthCheck resource for use in tests.
+type MachineHealthCheckParams struct {
+	Name         string
+	Labels       map[string]string
+	Conditions   []mhcv1beta1.UnhealthyCondition
+	MaxUnhealthy *int
+}
+
+// CreateMHC creates a new MachineHealthCheck resource.
+func CreateMHC(c client.Client, params MachineHealthCheckParams) (*mhcv1beta1.MachineHealthCheck, error) {
+	mhc := &mhcv1beta1.MachineHealthCheck{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machine.openshift.io/v1beta1",
+			Kind:       "MachineHealthCheck",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.Name,
+			Namespace: TestContext.MachineApiNamespace,
+		},
+		Spec: mhcv1beta1.MachineHealthCheckSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: params.Labels,
+			},
+			UnhealthyConditions: params.Conditions,
+		},
+	}
+
+	if params.MaxUnhealthy != nil {
+		maxUnhealthy := intstr.FromInt(*params.MaxUnhealthy)
+		mhc.Spec.MaxUnhealthy = &maxUnhealthy
+	}
+
+	if err := c.Create(context.Background(), mhc); err != nil {
+		return nil, err
+	}
+
+	return mhc, nil
+}

--- a/pkg/e2e/machinehealthcheck/machinehealthcheck.go
+++ b/pkg/e2e/machinehealthcheck/machinehealthcheck.go
@@ -1,0 +1,125 @@
+package machinehealthcheck
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
+	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	mhcv1beta1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck", func() {
+	var client client.Client
+
+	var machineSet *mapiv1beta1.MachineSet
+	var machineSetParams e2e.MachineSetParams
+
+	const E2EConditionType = "MachineHealthCheckE2E"
+
+	nodeCondition := corev1.NodeCondition{
+		Type:               E2EConditionType,
+		Status:             corev1.ConditionTrue,
+		LastHeartbeatTime:  metav1.Now(),
+		LastTransitionTime: metav1.Now(),
+		Reason:             "E2E",
+		Message:            "MachineHealthCheck E2E tests",
+	}
+
+	BeforeEach(func() {
+		var err error
+
+		client, err = e2e.LoadClient()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Get the current workers MachineSets so we can copy a ProviderSpec
+		// from one to use with our new dedicated MachineSet.
+		workers, err := e2e.GetWorkerMachineSets(client)
+		Expect(err).ToNot(HaveOccurred())
+
+		providerSpec := workers[0].Spec.Template.Spec.ProviderSpec.DeepCopy()
+		clusterName := workers[0].Spec.Template.Labels[e2e.ClusterKey]
+
+		// TODO(bison): This should probably be appended with
+		// something other than a timestamp, e.g. a random string.
+		msName := fmt.Sprintf("e2e-mhc-%d", time.Now().Unix())
+
+		machineSetParams = e2e.MachineSetParams{
+			Name:         msName,
+			Replicas:     3,
+			ProviderSpec: providerSpec,
+			Labels: map[string]string{
+				"mhc.e2e.openshift.io": msName,
+				e2e.ClusterKey:         clusterName,
+			},
+		}
+
+		By("Creating a new MachineSet")
+		machineSet, err = e2e.CreateMachineSet(client, machineSetParams)
+		Expect(err).ToNot(HaveOccurred())
+
+		e2e.WaitForMachineSet(client, machineSet.GetName())
+	})
+
+	AfterEach(func() {
+		By("Deleting the new MachineSet")
+		err := client.Delete(context.Background(), machineSet)
+		Expect(err).ToNot(HaveOccurred())
+
+		e2e.WaitForMachineSetDelete(client, machineSet)
+	})
+
+	It("should remediate unhealthy nodes", func() {
+		By("Setting conditions on a Node")
+
+		selector := machineSet.Spec.Selector
+		machines, err := e2e.GetMachines(context.Background(), client, &selector)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(machines).ToNot(BeEmpty())
+
+		machine := &machines[0]
+		node, err := e2e.GetNodeForMachine(client, machine)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = e2e.AddNodeCondition(client, node, nodeCondition)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Creating a MachineHealthCheck resource")
+		mhcParams := e2e.MachineHealthCheckParams{
+			Name:   machineSetParams.Name,
+			Labels: machineSetParams.Labels,
+			Conditions: []mhcv1beta1.UnhealthyCondition{
+				{
+					Type:    E2EConditionType,
+					Status:  corev1.ConditionTrue,
+					Timeout: "1s",
+				},
+			},
+		}
+
+		mhc, err := e2e.CreateMHC(client, mhcParams)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mhc).ToNot(BeNil())
+
+		By("Verifying the matching Machine is deleted")
+		e2e.WaitForMachineDelete(client, machine)
+
+		By("Verifying the MachineSet recovers")
+		e2e.WaitForMachineSet(client, machineSet.GetName())
+
+		By("Deleting the MachineHealthCheck resource")
+		err = client.Delete(context.Background(), mhc)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// It("should respect maxUnhealthy", func() {
+	// 	// TODO(bison): This.
+	// })
+})


### PR DESCRIPTION
This (re)adds an E2E test suite and associated helpers to cover the MachineHealthCheck feature. This now works with version v1beta1 of the MachineHealthCheck API. The tests operate on a dedicated MachineSet, which should allow things to be paralellized more easily in the future. 