### PR TITLE
Allow setting BUILD_DEST and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+WORKDIR /go/src/github.com/openshift/cluster-api-actuator-pkg
+COPY . .
+ENV NO_DOCKER=1
+ENV BUILD_DEST=/go/bin/cluster-api-e2e
+RUN unset VERSION && GOPROXY=off make build-e2e
+CMD ["/go/bin/cluster-api-e2e"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+BUILD_DEST ?= bin/cluster-api-e2e
+
 GO111MODULE = on
 export GO111MODULE
 GOFLAGS += -mod=vendor
@@ -57,7 +59,7 @@ vet: ## Apply go vet to all go files
 
 .PHONY: build-e2e
 build-e2e:
-	go test -c -o bin/e2e github.com/openshift/cluster-api-actuator-pkg/pkg/e2e
+	go test -c -o "$(BUILD_DEST)" github.com/openshift/cluster-api-actuator-pkg/pkg/e2e
 
 .PHONY: test-e2e
 test-e2e: ## Run openshift specific e2e test


### PR DESCRIPTION
This adds a Dockerfile so Prow can build an image containing the test suite.