### PR TITLE
[release-4.2] Bug 1776936: Add a random ID to machine names in infra tests

### DIFF
--- a/pkg/e2e/framework/common.go
+++ b/pkg/e2e/framework/common.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -25,6 +26,13 @@ const (
 	// if MachineSet.Spec.Replicas field is set to nil
 	DefaultMachineSetReplicas = 0
 )
+
+// RandomString returns a random 6 character string.
+func RandomString() string {
+	randID := string(uuid.NewUUID())
+
+	return randID[:6]
+}
 
 // GetNodes gets a list of nodes from a running cluster
 // Optionaly, labels may be used to constrain listed nodes.

--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -385,8 +385,9 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 
 		g.By("Creating two new machines, one for node about to be drained, other for moving workload from drained node")
 		// Create two machines
+		randID := e2e.RandomString()
 		machine1 := machineFromMachineset(&machinesets.Items[0])
-		machine1.Name = "machine1"
+		machine1.Name = "machine1-" + randID
 
 		var machine2 *mapiv1beta1.Machine
 		err = func() error {
@@ -396,7 +397,7 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 			delObjects["machine1"] = machine1
 
 			machine2 = machineFromMachineset(&machinesets.Items[0])
-			machine2.Name = "machine2"
+			machine2.Name = "machine2" + randID
 
 			if err := client.Create(context.TODO(), machine2); err != nil {
 				return fmt.Errorf("unable to create machine %q: %v", machine2.Name, err)


### PR DESCRIPTION
This is a cherry-pick of #124 to the release-4.2 branch. This adds a random ID to the machine names used in infra tests to avoid collisions.