### PR TITLE
[OCPCLOUD-765] Reduce test RC CPU to 40m

### DIFF
--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -56,7 +56,7 @@ func replicationControllerWorkload(namespace string) *corev1.ReplicationControll
 							Command: []string{"sleep", "10h"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									"cpu":    resource.MustParse("50m"),
+									"cpu":    resource.MustParse("40m"),
 									"memory": resource.MustParse("50Mi"),
 								},
 							},


### PR DESCRIPTION
On Azure, by default we only get 2 CPUs for each machine. During some tests, we attempt to fit a minimum of 19 of these pods on a single node. Currently the azure e2e suite is failing because the 19th pod becomes unschedulable as there is not enough CPU allocatable on a single node. Given this used to work I'm assuming someone modified the default reservations for kubelet and system CPU at some point in the openshift installer

Reducing to 40m will hopefully mean they still spread evenly across nodes initially, but will fit on the single azure instance once the test is underway