### PR TITLE
e2e: Prepend cluster name to machines in infra tests

### DIFF
--- a/pkg/e2e/framework/common.go
+++ b/pkg/e2e/framework/common.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	caov1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
 	caov1beta1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1"
@@ -22,11 +23,12 @@ import (
 )
 
 const (
-	WorkerNodeRoleLabel = "node-role.kubernetes.io/worker"
-	WaitShort           = 1 * time.Minute
-	WaitMedium          = 3 * time.Minute
-	WaitLong            = 15 * time.Minute
-	RetryMedium         = 5 * time.Second
+	GlobalInfrastuctureName = "cluster"
+	WorkerNodeRoleLabel     = "node-role.kubernetes.io/worker"
+	WaitShort               = 1 * time.Minute
+	WaitMedium              = 3 * time.Minute
+	WaitLong                = 15 * time.Minute
+	RetryMedium             = 5 * time.Second
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil
 	DefaultMachineSetReplicas = 0
@@ -42,6 +44,20 @@ func RandomString() string {
 	randID := string(uuid.NewUUID())
 
 	return randID[:6]
+}
+
+// GetInfrastructure fetches the global cluster infrastructure object.
+func GetInfrastructure(c client.Client) (*configv1.Infrastructure, error) {
+	infra := &configv1.Infrastructure{}
+	infraName := client.ObjectKey{
+		Name: GlobalInfrastuctureName,
+	}
+
+	if err := c.Get(context.Background(), infraName, infra); err != nil {
+		return nil, err
+	}
+
+	return infra, nil
 }
 
 // GetNodes gets a list of nodes from a running cluster

--- a/pkg/e2e/infra/infra.go
+++ b/pkg/e2e/infra/infra.go
@@ -384,10 +384,17 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Creating two new machines, one for node about to be drained, other for moving workload from drained node")
+		clusterInfra, err := e2e.GetInfrastructure(client)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(clusterInfra.Status.InfrastructureName).ShouldNot(o.BeEmpty())
+
 		// Create two machines
 		randID := e2e.RandomString()
 		machine1 := machineFromMachineset(&machinesets.Items[0])
-		machine1.Name = "machine1-" + randID
+		machine1.Name = fmt.Sprintf("%s-machine1-%s",
+			clusterInfra.Status.InfrastructureName,
+			randID,
+		)
 
 		var machine2 *mapiv1beta1.Machine
 		err = func() error {
@@ -398,6 +405,10 @@ var _ = g.Describe("[Feature:Machines] Managed cluster should", func() {
 
 			machine2 = machineFromMachineset(&machinesets.Items[0])
 			machine2.Name = "machine2" + randID
+			machine2.Name = fmt.Sprintf("%s-machine2-%s",
+				clusterInfra.Status.InfrastructureName,
+				randID,
+			)
 
 			if err := client.Create(context.TODO(), machine2); err != nil {
 				return fmt.Errorf("unable to create machine %q: %v", machine2.Name, err)


### PR DESCRIPTION
This prepends the cluster name, as found in the status of the global infrastructure object, to temporary machines created for e2e tests. This works around issues with the installer not tearing down resources that don't follow this naming scheme.
https://bugzilla.redhat.com/show_bug.cgi?id=1793051