### PR TITLE
Remove import aliases to make tests more readable

### DIFF
--- a/pkg/e2e/e2e_test.go
+++ b/pkg/e2e/e2e_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/golang/glog"
-	g "github.com/onsi/ginkgo"
-	o "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
@@ -38,6 +38,6 @@ func init() {
 }
 
 func TestE2E(t *testing.T) {
-	o.RegisterFailHandler(g.Fail)
-	g.RunSpecs(t, "Machine Suite")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Machine Suite")
 }

--- a/pkg/e2e/operators/cluster-autoscaler-operator.go
+++ b/pkg/e2e/operators/cluster-autoscaler-operator.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	g "github.com/onsi/ginkgo"
-	o "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -15,22 +16,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = g.Describe("[Feature:Operators] Cluster autoscaler operator should", func() {
+var _ = Describe("[Feature:Operators] Cluster autoscaler operator should", func() {
 	var client runtimeclient.Client
 
-	defer g.GinkgoRecover()
+	defer GinkgoRecover()
 
-	g.BeforeEach(func() {
+	BeforeEach(func() {
 		var err error
 
 		client, err = e2e.LoadClient()
-		o.Expect(err).NotTo(o.HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		ok := waitForValidatingWebhook(client, "autoscaling.openshift.io")
-		o.Expect(ok).To(o.BeTrue())
+		Expect(ok).To(BeTrue())
 	})
 
-	g.It("reject invalid ClusterAutoscaler resources early via webhook", func() {
+	It("reject invalid ClusterAutoscaler resources early via webhook", func() {
 		invalidCA := &caov1.ClusterAutoscaler{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ClusterAutoscaler",
@@ -43,10 +44,10 @@ var _ = g.Describe("[Feature:Operators] Cluster autoscaler operator should", fun
 		}
 
 		err := client.Create(context.TODO(), invalidCA)
-		o.Expect(err).To(o.HaveOccurred())
+		Expect(err).To(HaveOccurred())
 	})
 
-	g.It("reject invalid MachineAutoscaler resources early via webhook", func() {
+	It("reject invalid MachineAutoscaler resources early via webhook", func() {
 		invalidMA := &caov1beta1.MachineAutoscaler{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "MachineAutoscaler",
@@ -69,28 +70,28 @@ var _ = g.Describe("[Feature:Operators] Cluster autoscaler operator should", fun
 		}
 
 		err := client.Create(context.TODO(), invalidMA)
-		o.Expect(err).To(o.HaveOccurred())
+		Expect(err).To(HaveOccurred())
 	})
 })
 
-var _ = g.Describe("[Feature:Operators] Cluster autoscaler operator deployment should", func() {
-	defer g.GinkgoRecover()
+var _ = Describe("[Feature:Operators] Cluster autoscaler operator deployment should", func() {
+	defer GinkgoRecover()
 
-	g.It("be available", func() {
+	It("be available", func() {
 		var err error
 		client, err := e2e.LoadClient()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(e2e.IsDeploymentAvailable(client, "cluster-autoscaler-operator")).To(o.BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(e2e.IsDeploymentAvailable(client, "cluster-autoscaler-operator")).To(BeTrue())
 	})
 })
 
-var _ = g.Describe("[Feature:Operators] Cluster autoscaler cluster operator status should", func() {
-	defer g.GinkgoRecover()
+var _ = Describe("[Feature:Operators] Cluster autoscaler cluster operator status should", func() {
+	defer GinkgoRecover()
 
-	g.It("be available", func() {
+	It("be available", func() {
 		var err error
 		client, err := e2e.LoadClient()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(isStatusAvailable(client, "cluster-autoscaler")).To(o.BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isStatusAvailable(client, "cluster-autoscaler")).To(BeTrue())
 	})
 })

--- a/pkg/e2e/operators/machine-api-operator.go
+++ b/pkg/e2e/operators/machine-api-operator.go
@@ -3,8 +3,8 @@ package operators
 import (
 	"fmt"
 
-	g "github.com/onsi/ginkgo"
-	o "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
 )
 
@@ -12,48 +12,48 @@ var (
 	deploymentDeprecatedName = "clusterapi-manager-controllers"
 )
 
-var _ = g.Describe("[Feature:Operators] Machine API operator deployment should", func() {
-	defer g.GinkgoRecover()
+var _ = Describe("[Feature:Operators] Machine API operator deployment should", func() {
+	defer GinkgoRecover()
 
-	g.It("be available", func() {
+	It("be available", func() {
 		var err error
 		client, err := e2e.LoadClient()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(e2e.IsDeploymentAvailable(client, "machine-api-operator")).To(o.BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(e2e.IsDeploymentAvailable(client, "machine-api-operator")).To(BeTrue())
 	})
 
-	g.It("reconcile controllers deployment", func() {
+	It("reconcile controllers deployment", func() {
 		var err error
 		client, err := e2e.LoadClient()
-		o.Expect(err).NotTo(o.HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		deploymentName := "machine-api-controllers"
 		initialDeployment, err := e2e.GetDeployment(client, deploymentName)
 		if err != nil {
 			initialDeployment, err = e2e.GetDeployment(client, deploymentDeprecatedName)
-			o.Expect(err).NotTo(o.HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			deploymentName = deploymentDeprecatedName
 		}
 
-		g.By(fmt.Sprintf("checking deployment %q is available", deploymentName))
-		o.Expect(e2e.IsDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
+		By(fmt.Sprintf("checking deployment %q is available", deploymentName))
+		Expect(e2e.IsDeploymentAvailable(client, deploymentName)).To(BeTrue())
 
-		g.By(fmt.Sprintf("deleting deployment %q", deploymentName))
+		By(fmt.Sprintf("deleting deployment %q", deploymentName))
 		err = e2e.DeleteDeployment(client, initialDeployment)
-		o.Expect(err).NotTo(o.HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
-		g.By(fmt.Sprintf("checking deployment %q is available again", deploymentName))
-		o.Expect(e2e.IsDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
+		By(fmt.Sprintf("checking deployment %q is available again", deploymentName))
+		Expect(e2e.IsDeploymentAvailable(client, deploymentName)).To(BeTrue())
 	})
 })
 
-var _ = g.Describe("[Feature:Operators] Machine API cluster operator status should", func() {
-	defer g.GinkgoRecover()
+var _ = Describe("[Feature:Operators] Machine API cluster operator status should", func() {
+	defer GinkgoRecover()
 
-	g.It("be available", func() {
+	It("be available", func() {
 		var err error
 		client, err := e2e.LoadClient()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(isStatusAvailable(client, "machine-api")).To(o.BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isStatusAvailable(client, "machine-api")).To(BeTrue())
 	})
 })


### PR DESCRIPTION
Remove import aliases to make tests more readable.