### PR TITLE
[OCPCLOUD-789] Allow E2E suite to output JUnit files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,12 @@ test-e2e: ## Run openshift specific e2e test
 	# failures and flakes.
 	# Feature:Operator tests remove deployments. Thus loosing all the logs
 	# previously acquired.
-	hack/ci-integration.sh $(GINKGO_ARGS) -focus="Feature:Operators"
-	hack/ci-integration.sh $(GINKGO_ARGS) -skip="Feature:Operators|Autoscaler"
+	hack/ci-integration.sh $(GINKGO_ARGS) -focus="Feature:Operators" || (hack/junitmerge.sh && exit 1)
+	hack/ci-integration.sh $(GINKGO_ARGS) -skip="Feature:Operators|Autoscaler" || (hack/junitmerge.sh && exit 1)
 	# TODO: parallelise autoscaler
-	hack/ci-integration.sh $(GINKGO_ARGS) -focus="Autoscaler"
+	hack/ci-integration.sh $(GINKGO_ARGS) -focus="Autoscaler" || (hack/junitmerge.sh && exit 1)
+	# After success, merge all JUnit files into one
+	hack/junitmerge.sh
 
 test-e2e-tech-preview:
 	hack/ci-integration.sh $(GINKGO_ARGS) -focus="TechPreview"

--- a/hack/junitmerge.sh
+++ b/hack/junitmerge.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+function find::junitmerge () {
+  local binary_name="junitmerge"
+
+	local old_ifs="${IFS}"
+	IFS=":"
+	for part in ${GOPATH}; do
+		local binary_path="${part}/bin/${binary_name}"
+		# we need to check that the path leads to a file
+		# as directories also have the executable bit set
+		if [[ -f "${binary_path}" && -x "${binary_path}" ]]; then
+			echo "${binary_path}"
+			IFS="${old_ifs}"
+			return 0
+		fi
+	done
+	IFS="${old_ifs}"
+	return 1
+}
+
+function ensure::junitmerge () {
+  if ! find::junitmerge >/dev/null 2>&1; then
+    # File does not exist, fetch it
+    GO111MODULE=off go get github.com/openshift/release/tools/junitmerge
+  fi
+}
+
+# Check there are files to merge
+if ! ls "${JUNIT_DIR}"/junit_cluster_api_actuator_pkg_e2e_*.xml 1> /dev/null 2>&1 ; then
+  echo "No files to merge"
+  exit 0
+fi
+
+ensure::junitmerge
+
+# If JUNIT_DIR is not set, no JUnit reports to merge
+if [[ -z "${JUNIT_DIR:-}" ]]; then
+	return
+fi
+
+output="$( mktemp )"
+"$( find::junitmerge )" "${JUNIT_DIR}"/junit_cluster_api_actuator_pkg_e2e_*.xml > "${output}"
+rm "${JUNIT_DIR}"/*.xml
+mv "${output}" "${JUNIT_DIR}/junit_cluster_api_actuator_pkg_e2e.xml"

--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -1,10 +1,15 @@
 package e2e
 
 import (
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
@@ -18,6 +23,8 @@ import (
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/machinehealthcheck"
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/operators"
 )
+
+const junitDirEnvVar = "JUNIT_DIR"
 
 func init() {
 	if err := mapiv1beta1.AddToScheme(scheme.Scheme); err != nil {
@@ -39,5 +46,17 @@ func init() {
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Machine Suite")
+	RunSpecsWithDefaultAndCustomReporters(t, "Machine Suite", e2eReporters())
+}
+
+func e2eReporters() []Reporter {
+	reportDir := os.Getenv(junitDirEnvVar)
+	if reportDir != "" {
+		// Include `ParallelNode` so tests running in parallel do not overwrite the same file.
+		// Include timestamp so test suite can be called multiple times with focus within same CI job
+		// without overwriting files.
+		junitFileName := fmt.Sprintf("%s/junit_cluster_api_actuator_pkg_e2e_%d_%d.xml", reportDir, time.Now().UnixNano(), config.GinkgoConfig.ParallelNode)
+		return []Reporter{reporters.NewJUnitReporter(junitFileName)}
+	}
+	return []Reporter{}
 }


### PR DESCRIPTION
This enables packages using this test suite to output JUnit reports for consumption by Prow, this will make it easier to interpret test failures within these tests

Adding `JUNIT_DIR=$ARTIFACTS` when running the test suite should result in this being picked up by Prow