### PR TITLE
Only add -mod=vendor when GOFLAGS not already set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BUILD_DEST ?= bin/cluster-api-e2e
 
 GO111MODULE = on
 export GO111MODULE
-GOFLAGS += -mod=vendor
+GOFLAGS ?= -mod=vendor
 export GOFLAGS
 GOPROXY ?=
 export GOPROXY


### PR DESCRIPTION
Actuator tests are currently broken [[example](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/550/pull-ci-openshift-machine-api-operator-master-e2e-aws-operator/1892)] with the error:

```
Failed to compile pkg:
go test: mod flag may be set only once
run "go help test" or "go help testflag" for more information
```

This should fix that