### PR TITLE
Bug 1838523: Wrap API errors in framework

### DIFF
--- a/pkg/framework/clusterautoscalers.go
+++ b/pkg/framework/clusterautoscalers.go
@@ -14,7 +14,7 @@ func GetClusterAutoscaler(client runtimeclient.Client, name string) (*caov1.Clus
 	key := runtimeclient.ObjectKey{Namespace: MachineAPINamespace, Name: name}
 
 	if err := client.Get(context.Background(), key, clusterAutoscaler); err != nil {
-		return nil, fmt.Errorf("error querying api for ClusterAutoscaler object: %v", err)
+		return nil, fmt.Errorf("error querying api for ClusterAutoscaler object: %w", err)
 	}
 
 	return clusterAutoscaler, nil

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -50,7 +50,7 @@ const (
 // - batchv1.JobList
 func DeleteObjectsByLabels(c runtimeclient.Client, labels map[string]string, list runtime.Object) error {
 	if err := c.List(context.Background(), list, runtimeclient.MatchingLabels(labels)); err != nil {
-		return fmt.Errorf("Unable to list objects: %v", err)
+		return fmt.Errorf("Unable to list objects: %w", err)
 	}
 
 	// TODO(jchaloup): find a way how to list the items independent of a kind
@@ -78,7 +78,7 @@ func DeleteObjectsByLabels(c runtimeclient.Client, labels map[string]string, lis
 		if err := c.Delete(context.Background(), obj, &runtimeclient.DeleteOptions{
 			PropagationPolicy: &cascadeDelete,
 		}); err != nil {
-			return fmt.Errorf("error deleting object: %v", err)
+			return fmt.Errorf("error deleting object: %w", err)
 		}
 	}
 

--- a/pkg/framework/machines.go
+++ b/pkg/framework/machines.go
@@ -38,7 +38,7 @@ func GetMachine(c client.Client, name string) (*mapiv1beta1.Machine, error) {
 	key := client.ObjectKey{Namespace: MachineAPINamespace, Name: name}
 
 	if err := c.Get(context.Background(), key, machine); err != nil {
-		return nil, fmt.Errorf("error querying api for machine object: %v", err)
+		return nil, fmt.Errorf("error querying api for machine object: %w", err)
 	}
 
 	return machine, nil
@@ -65,7 +65,7 @@ func GetMachines(client runtimeclient.Client, selectors ...*metav1.LabelSelector
 	}
 
 	if err := client.List(context.Background(), machineList, listOpts...); err != nil {
-		return nil, fmt.Errorf("error querying api for machineList object: %v", err)
+		return nil, fmt.Errorf("error querying api for machineList object: %w", err)
 	}
 
 	var machines []*mapiv1beta1.Machine
@@ -97,7 +97,7 @@ func GetMachineFromNode(client runtimeclient.Client, node *corev1.Node) (*mapiv1
 
 	machine, err := GetMachine(client, machineName)
 	if err != nil {
-		return nil, fmt.Errorf("error querying api for machine object: %v", err)
+		return nil, fmt.Errorf("error querying api for machine object: %w", err)
 	}
 
 	return machine, nil

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -128,7 +128,7 @@ func GetMachineSets(client runtimeclient.Client, selectors ...*metav1.LabelSelec
 	}
 
 	if err := client.List(context.Background(), machineSetList, listOpts...); err != nil {
-		return nil, fmt.Errorf("error querying api for machineSetList object: %v", err)
+		return nil, fmt.Errorf("error querying api for machineSetList object: %w", err)
 	}
 
 	return machineSetList.Items, nil
@@ -140,7 +140,7 @@ func GetMachineSet(client runtimeclient.Client, name string) (*mapiv1beta1.Machi
 	key := runtimeclient.ObjectKey{Namespace: MachineAPINamespace, Name: name}
 
 	if err := client.Get(context.Background(), key, machineSet); err != nil {
-		return nil, fmt.Errorf("error querying api for machineSet object: %v", err)
+		return nil, fmt.Errorf("error querying api for machineSet object: %w", err)
 	}
 
 	return machineSet, nil
@@ -179,7 +179,7 @@ func GetWorkerMachineSets(client runtimeclient.Client) ([]*mapiv1beta1.MachineSe
 func GetMachinesFromMachineSet(client runtimeclient.Client, machineSet *mapiv1beta1.MachineSet) ([]*mapiv1beta1.Machine, error) {
 	machines, err := GetMachines(client)
 	if err != nil {
-		return nil, fmt.Errorf("error getting machines: %v", err)
+		return nil, fmt.Errorf("error getting machines: %w", err)
 	}
 	var machinesForSet []*mapiv1beta1.Machine
 	for key := range machines {
@@ -252,19 +252,19 @@ func NewMachineSet(
 func ScaleMachineSet(name string, replicas int) error {
 	scaleClient, err := getScaleClient()
 	if err != nil {
-		return fmt.Errorf("error calling getScaleClient %v", err)
+		return fmt.Errorf("error calling getScaleClient %w", err)
 	}
 
 	scale, err := scaleClient.Scales(MachineAPINamespace).Get(context.Background(), schema.GroupResource{Group: machineAPIGroup, Resource: "MachineSet"}, name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("error calling scaleClient.Scales get: %v", err)
+		return fmt.Errorf("error calling scaleClient.Scales get: %w", err)
 	}
 
 	scaleUpdate := scale.DeepCopy()
 	scaleUpdate.Spec.Replicas = int32(replicas)
 	_, err = scaleClient.Scales(MachineAPINamespace).Update(context.Background(), schema.GroupResource{Group: machineAPIGroup, Resource: "MachineSet"}, scaleUpdate, metav1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("error calling scaleClient.Scales update: %v", err)
+		return fmt.Errorf("error calling scaleClient.Scales update: %w", err)
 	}
 	return nil
 }
@@ -273,18 +273,18 @@ func ScaleMachineSet(name string, replicas int) error {
 func getScaleClient() (scale.ScalesGetter, error) {
 	cfg, err := config.GetConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error getting config %v", err)
+		return nil, fmt.Errorf("error getting config %w", err)
 	}
 	mapper, err := apiutil.NewDiscoveryRESTMapper(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("error calling NewDiscoveryRESTMapper %v", err)
+		return nil, fmt.Errorf("error calling NewDiscoveryRESTMapper %w", err)
 	}
 
 	discovery := discovery.NewDiscoveryClientForConfigOrDie(cfg)
 	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(discovery)
 	scaleClient, err := scale.NewForConfig(cfg, mapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
 	if err != nil {
-		return nil, fmt.Errorf("error calling building scale client %v", err)
+		return nil, fmt.Errorf("error calling building scale client %w", err)
 	}
 	return scaleClient, nil
 }

--- a/pkg/framework/nodes.go
+++ b/pkg/framework/nodes.go
@@ -55,7 +55,7 @@ func GetNodes(c client.Client, selectors ...*metav1.LabelSelector) ([]corev1.Nod
 	}
 
 	if err := c.List(context.TODO(), &nodeList, listOpts...); err != nil {
-		return nil, fmt.Errorf("error querying api for nodeList object: %v", err)
+		return nil, fmt.Errorf("error querying api for nodeList object: %w", err)
 	}
 
 	return nodeList.Items, nil
@@ -65,14 +65,14 @@ func GetNodes(c client.Client, selectors ...*metav1.LabelSelector) ([]corev1.Nod
 func GetNodesFromMachineSet(client runtimeclient.Client, machineSet *mapiv1beta1.MachineSet) ([]*corev1.Node, error) {
 	machines, err := GetMachinesFromMachineSet(client, machineSet)
 	if err != nil {
-		return nil, fmt.Errorf("error calling getMachinesFromMachineSet %v", err)
+		return nil, fmt.Errorf("error calling getMachinesFromMachineSet %w", err)
 	}
 
 	var nodes []*corev1.Node
 	for key := range machines {
 		node, err := GetNodeForMachine(client, machines[key])
 		if err != nil {
-			return nil, fmt.Errorf("error getting node from machine %q: %v", machines[key].Name, err)
+			return nil, fmt.Errorf("error getting node from machine %q: %w", machines[key].Name, err)
 		}
 		nodes = append(nodes, node)
 	}


### PR DESCRIPTION
By wrapping these errors, we preserve the underlying API error types which allows the errors to be read by the [apimachinery errors](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/errors/errors.go) package. 
This allows tests to determine the cause of an error and act appropriately. Eg you can tell if a resource does not exist vs a connection timeout error.