### PR TITLE
OCPCLOUD-439 - Make "recover from deleted worker machines" test more disruptive

### DIFF
--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -229,12 +229,10 @@ var _ = Describe("[Feature:Machines] Managed cluster should", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(machines).ToNot(BeEmpty())
 
-		machine := machines[0]
-
-		By(fmt.Sprintf("deleting machine object %q", machine.Name))
-		err = framework.DeleteMachine(client, machine)
+		By(fmt.Sprint("deleting all machines"))
+		err = framework.DeleteMachines(client, machines...)
 		Expect(err).NotTo(HaveOccurred())
-		framework.WaitForMachineDelete(client, machine)
+		framework.WaitForMachinesDeleted(client, machines...)
 
 		framework.WaitForMachineSet(client, machineSet.GetName())
 	})
@@ -322,7 +320,7 @@ var _ = Describe("[Feature:Machines] Managed cluster should", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating the machine is deleted")
-		framework.WaitForMachineDelete(client, machines[0])
+		framework.WaitForMachinesDeleted(client, machines[0])
 
 		By("Validate underlying node corresponding to machine1 is removed as well")
 		err = framework.WaitUntilNodeDoesNotExists(client, drainedNodeName)

--- a/pkg/machinehealthcheck/machinehealthcheck.go
+++ b/pkg/machinehealthcheck/machinehealthcheck.go
@@ -108,7 +108,7 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck", func() {
 		Expect(mhc).ToNot(BeNil())
 
 		By("Verifying the matching Machine is deleted")
-		framework.WaitForMachineDelete(client, machine)
+		framework.WaitForMachinesDeleted(client, machine)
 
 		By("Verifying the MachineSet recovers")
 		framework.WaitForMachineSet(client, machineSet.GetName())


### PR DESCRIPTION
Ensure e2e test check recovery from all machines deletion