### PR TITLE
change autoscaler tests to use allocatable ram

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -231,10 +231,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(workerNodes)).To(BeNumerically(">=", 1))
 
-		memCapacity := workerNodes[0].Status.Capacity[corev1.ResourceMemory]
+		memCapacity := workerNodes[0].Status.Allocatable[corev1.ResourceMemory]
 		Expect(memCapacity).ShouldNot(BeNil())
 		Expect(memCapacity.String()).ShouldNot(BeEmpty())
-		klog.Infof("Memory capacity of worker node %q is %s", workerNodes[0].Name, memCapacity.String())
+		klog.Infof("Allocatable memory capacity of worker node %q is %s", workerNodes[0].Name, memCapacity.String())
 
 		bytes, ok := memCapacity.AsInt64()
 		Expect(ok).Should(BeTrue())


### PR DESCRIPTION
This change switches the way the autoscaler tests calculate the usable
ram on worker nodes for the purpose of building resource requirements
for workload jobs. Prior to this commit, the tests have been using the
memory capacity of a node to determine the resource requirement. This
behavior can lead to failures in cases where the amount of actual
allocatable ram differs significantly from the capacity. This change
simply changes the calculation function to use the allocatable ram.