### PR TITLE
Allow longer period for tests to pass on slower providers

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -30,9 +30,6 @@ const (
 	MachineAPINamespace     = "openshift-machine-api"
 	GlobalInfrastuctureName = "cluster"
 	WorkerNodeRoleLabel     = "node-role.kubernetes.io/worker"
-	WaitShort               = 1 * time.Minute
-	WaitMedium              = 3 * time.Minute
-	WaitLong                = 15 * time.Minute
 	RetryShort              = 1 * time.Second
 	RetryMedium             = 5 * time.Second
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
@@ -42,6 +39,12 @@ const (
 	MachineRoleLabel          = "machine.openshift.io/cluster-api-machine-role"
 	MachineTypeLabel          = "machine.openshift.io/cluster-api-machine-type"
 	MachineAnnotationKey      = "machine.openshift.io/machine"
+)
+
+var (
+	WaitShort  = 1 * time.Minute
+	WaitMedium = 3 * time.Minute
+	WaitLong   = 15 * time.Minute
 )
 
 // DeleteObjectsByLabels list all objects of a given kind by labels and deletes them.


### PR DESCRIPTION
This PR extends the timeouts we set on our E2E tests for providers that are slower at starting and stopping machines.

Also includes the contents of #169 which I was trying to test separately (hoping it would pass on it's own accord)