### PR TITLE
Reduce flakiness of autoscaler tests

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -653,7 +653,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 					}
 				}
 				return true, nil
-			}, framework.WaitMedium, pollingInterval).Should(BeTrue())
+			}, framework.WaitLong, pollingInterval).Should(BeTrue())
 
 			for _, machineSet := range transientMachineSets {
 				machines, err := framework.GetMachinesFromMachineSet(client, machineSet)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -269,21 +269,22 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			existingMachineSets, err := framework.GetMachineSets(client)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(existingMachineSets)).To(BeNumerically(">=", 1))
-
-			By("Getting existing machines")
-			existingMachines, err := framework.GetMachines(client)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(existingMachines)).To(BeNumerically(">=", 1))
-
-			By("Getting existing nodes")
-			existingNodes, err := framework.GetNodes(client)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(existingNodes)).To(BeNumerically(">=", 1))
-
 			klog.Infof("Have %v existing machinesets", len(existingMachineSets))
-			klog.Infof("Have %v existing machines", len(existingMachines))
-			klog.Infof("Have %v existing nodes", len(existingNodes))
-			Expect(len(existingNodes) == len(existingMachines)).To(BeTrue())
+
+			By("Checking that the number of machines and nodes is stable")
+			Eventually(func() (bool, error) {
+				existingMachines, err := framework.GetMachines(client)
+				if err != nil {
+					return false, err
+				}
+				existingNodes, err := framework.GetNodes(client)
+				if err != nil {
+					return false, err
+				}
+				klog.Infof("Have %v existing machines", len(existingMachines))
+				klog.Infof("Have %v existing nodes", len(existingNodes))
+				return len(existingMachines) == len(existingNodes) && len(existingNodes) > 0, nil
+			}, framework.WaitMedium, framework.RetryMedium).Should(BeTrue())
 
 			// The remainder of the logic in this test requires 3
 			// machinesets.


### PR DESCRIPTION
I've update two of the test cases that appeared to be flaky while I've been looking into the Azure E2E failures.

From what I can tell, it can sometimes take longer than expected to shut down machines based on which provider we are using.

The first test that I updated expected that the machine count and node count should be equal at the beginning of the test, while this may be true, I don't see any reason why we shouldn't give the test a moment to stabilise before starting, so now we give it a `WaitMedium` to allow the nodes/machines to fully shut down from previous tests before starting this one.

Eg:
- https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-api-actuator-pkg/167/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e-aws-operator/1277971520013996032

The second test expected that once a termination had been requested for a machine, that it would be completely shutdown within `WaitMedium`, this does not appear to be the case for Azure and it was consistently failing to shutdown machines during within this timeout

Eg:
- https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-api-actuator-pkg/168/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e-azure-operator/1278735958425997312
- https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-api-actuator-pkg/166/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e-azure-operator/1278680115689033728
- https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-api-actuator-pkg/167/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e-azure-operator/1278668987076448256