### PR TITLE
Degraded validation

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -120,14 +120,14 @@ func LoadClientset() (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(cfg)
 }
 
-func IsStatusAvailable(client runtimeclient.Client, name string) bool {
+func WaitForStatusAvailable(client runtimeclient.Client, name string) bool {
 	key := types.NamespacedName{
 		Namespace: MachineAPINamespace,
 		Name:      name,
 	}
 	clusterOperator := &configv1.ClusterOperator{}
 
-	if err := wait.PollImmediate(RetryShort, WaitShort, func() (bool, error) {
+	if err := wait.PollImmediate(RetryShort, 10*time.Minute, func() (bool, error) {
 		if err := client.Get(context.TODO(), key, clusterOperator); err != nil {
 			klog.Errorf("error querying api for OperatorStatus object: %v, retrying...", err)
 			return false, nil

--- a/pkg/operators/cluster-autoscaler-operator.go
+++ b/pkg/operators/cluster-autoscaler-operator.go
@@ -92,6 +92,6 @@ var _ = Describe("[Feature:Operators] Cluster autoscaler cluster operator status
 		var err error
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(framework.IsStatusAvailable(client, "cluster-autoscaler")).To(BeTrue())
+		Expect(framework.WaitForStatusAvailable(client, "cluster-autoscaler")).To(BeTrue())
 	})
 })

--- a/pkg/operators/cluster-machine-approver.go
+++ b/pkg/operators/cluster-machine-approver.go
@@ -26,6 +26,6 @@ var _ = Describe("[Feature:Operators] Cluster Machine Approver Cluster Operator 
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(framework.IsStatusAvailable(client, cmaClusterOperator)).To(BeTrue())
+		Expect(framework.WaitForStatusAvailable(client, cmaClusterOperator)).To(BeTrue())
 	})
 })

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -1,12 +1,16 @@
 package operators
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -74,5 +78,46 @@ var _ = Describe("[Feature:Operators] Machine API cluster operator status should
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(framework.IsStatusAvailable(client, "machine-api")).To(BeTrue())
+	})
+
+	It("be degraded when a pod owned by the operator is prevented from being available", func() {
+		c, err := framework.LoadClient()
+		Expect(err).NotTo(HaveOccurred())
+
+		// https://github.com/openshift/machine-api-operator/blob/d234cceb5de18b83aa0609d17db7d835f2d78973/pkg/operator/sync.go#L310-L313
+		mAPIControllersLabels := map[string]string{
+			"api":     "clusterapi",
+			"k8s-app": "controller",
+		}
+
+		Eventually(func() (bool, error) {
+			// get machine API controllers pods
+			podList := &v1.PodList{}
+			if err := c.List(context.TODO(), podList, client.MatchingLabels(mAPIControllersLabels)); err != nil {
+				klog.Errorf("failed to list pods: %v", err)
+				return false, nil
+			}
+			if len(podList.Items) < 1 {
+				klog.Errorf("list of pods is empty")
+				return false, nil
+			}
+
+			// delete machine API controllers pods
+			for k := range podList.Items {
+				if err := c.Delete(context.Background(), &podList.Items[k]); err != nil {
+					klog.Errorf("failed to delete pod: %v", err)
+					return false, nil
+				}
+			}
+
+			isStatusDegraded, err := framework.IsStatusDegraded(c, "machine-api")
+			if err != nil {
+				return false, nil
+			}
+
+			return isStatusDegraded, nil
+		}, framework.WaitLong, framework.RetryShort).Should(BeTrue())
+
+		Expect(framework.IsStatusAvailable(c, "machine-api")).To(BeTrue())
 	})
 })

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -77,7 +77,7 @@ var _ = Describe("[Feature:Operators] Machine API cluster operator status should
 	It("be available", func() {
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(framework.IsStatusAvailable(client, "machine-api")).To(BeTrue())
+		Expect(framework.WaitForStatusAvailable(client, "machine-api")).To(BeTrue())
 	})
 
 	It("be degraded when a pod owned by the operator is prevented from being available", func() {
@@ -118,6 +118,6 @@ var _ = Describe("[Feature:Operators] Machine API cluster operator status should
 			return isStatusDegraded, nil
 		}, framework.WaitLong, framework.RetryShort).Should(BeTrue())
 
-		Expect(framework.IsStatusAvailable(c, "machine-api")).To(BeTrue())
+		Expect(framework.WaitForStatusAvailable(c, "machine-api")).To(BeTrue())
 	})
 })


### PR DESCRIPTION
The first commit introduces a validation for the machine-api clusterOperator going degraded.
The second commit renames IsStatusAvailable -> WaitForStatusAvailable and increase the waiting timeout. This is needed as we are testing status transitions now. Names for funcs which run actions in loop should be prefixed with wait.
So if the specific action need to be called within any other "eventually" func it can be name appriopriately e.g IsStatusAvailable.
The timeout is increased so this can succeed for status transitions. E.g the mao will wait for a pod to be running for at least 3min before considering it available.
https://github.com/openshift/machine-api-operator/blob/master/pkg/operator/sync.go#L28

This PR is to test https://github.com/openshift/machine-api-operator/pull/651