### PR TITLE
BUG 1856344: [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -42,9 +42,10 @@ const (
 )
 
 var (
-	WaitShort  = 1 * time.Minute
-	WaitMedium = 3 * time.Minute
-	WaitLong   = 15 * time.Minute
+	WaitShort    = 1 * time.Minute
+	WaitMedium   = 3 * time.Minute
+	WaitLong     = 15 * time.Minute
+	WaitOverLong = 30 * time.Minute
 )
 
 // DeleteObjectsByLabels list all objects of a given kind by labels and deletes them.

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -308,15 +308,16 @@ func WaitForMachineSet(c client.Client, name string) {
 		replicas := pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, 0)
 
 		if len(machines) != int(replicas) {
-			return fmt.Errorf("found %d Machines, but MachineSet has %d replicas",
-				len(machines), int(replicas))
+			return fmt.Errorf("%q: found %d Machines, but MachineSet has %d replicas",
+				name, len(machines), int(replicas))
 		}
 
 		running := FilterRunningMachines(machines)
 
 		// This could probably be smarter, but seems fine for now.
 		if len(running) != len(machines) {
-			return fmt.Errorf("not all Machines are running")
+			return fmt.Errorf("%q: not all Machines are running: %d of %d",
+				name, len(running), len(machines))
 		}
 
 		for _, m := range running {
@@ -331,7 +332,7 @@ func WaitForMachineSet(c client.Client, name string) {
 		}
 
 		return nil
-	}, WaitLong, RetryMedium).ShouldNot(HaveOccurred())
+	}, WaitOverLong, RetryMedium).ShouldNot(HaveOccurred())
 }
 
 // WaitForMachineSetDelete polls until the given MachineSet is not found, and


### PR DESCRIPTION
 Increase timeout for machineSet readiness (Azure) to `30 min` now.

Attempt to increase e2e tests stability on Azure, by increasing `machineSet` timeouts even further, and exposing more detailed information about failure reason.