### PR TITLE
Fail fast if machines enter Failed phase

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -36,6 +36,7 @@ const (
 	// if MachineSet.Spec.Replicas field is set to nil
 	DefaultMachineSetReplicas = 0
 	MachinePhaseRunning       = "Running"
+	MachinePhaseFailed        = "Failed"
 	MachineRoleLabel          = "machine.openshift.io/cluster-api-machine-role"
 	MachineTypeLabel          = "machine.openshift.io/cluster-api-machine-type"
 	MachineAnnotationKey      = "machine.openshift.io/machine"

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -312,7 +312,8 @@ func WaitForMachineSet(c client.Client, name string) {
 				name, len(machines), int(replicas))
 		}
 
-		running := FilterRunningMachines(machines)
+		running, err := FilterRunningMachines(machines)
+		Expect(err).ToNot(HaveOccurred())
 
 		// This could probably be smarter, but seems fine for now.
 		if len(running) != len(machines) {

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -85,7 +85,8 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 			if err != nil {
 				return err
 			}
-			running := framework.FilterRunningMachines([]*mapiv1.Machine{m})
+			running, err := framework.FilterRunningMachines([]*mapiv1.Machine{m})
+			Expect(err).ToNot(HaveOccurred())
 			if len(running) == 0 {
 				return fmt.Errorf("machine not yet running")
 			}


### PR DESCRIPTION
According to MAO specifics, machines entering `Failed` phase will no longer be provisioned or processed. This commit ensures that `e2e` tests requiring machines to enter `Running` phase, or waiting for a full `MachineSet` rollout, would fail faster and give more readable failure output, instead of a generic timeout on condition.

This will help improve CI readability.