### PR TITLE
Loop metadata service connections to localhost

### DIFF
--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -365,6 +365,7 @@ export SERVICE_IP=$(dig +short ${MOCK_SERVICE_NAME}.${NAMESPACE}.svc.cluster.loc
 if [ -z ${SERVICE_IP} ]; then echo "No service IP"; exit 1; fi;
 iptables-nft -t nat -A OUTPUT -p tcp -d 169.254.169.254 -j DNAT --to-destination ${SERVICE_IP}:${MOCK_SERVICE_PORT};
 iptables-nft -t nat -A POSTROUTING -j MASQUERADE;
+ifconfig lo:0 169.254.169.254 up;
 echo "Redirected metadata service to ${SERVICE_IP}:${MOCK_SERVICE_PORT}";`
 
 	fileOrCreate := corev1.HostPathFileOrCreate


### PR DESCRIPTION
This ensures that all outbound connections to the metadata service are looped back to localhost, this forces the traffic through the iptables rules set up earlier in this script, proxying the traffic to the fake metadata service