### PR TITLE
Merge spot tests to a single test

### DIFF
--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -184,7 +184,9 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 			})
 
 			// If the job deploys correctly, the Machine will go away
-			framework.WaitForMachinesDeleted(client, machine)
+			By(fmt.Sprintf("Waiting for machine %q to be deleted", machine.Name), func() {
+				framework.WaitForMachinesDeleted(client, machine)
+			})
 		})
 	})
 })


### PR DESCRIPTION
This means that the test suite only needs to spin up a single machineset for spot instances.

This is an easy alternative to having a `BeforeAll` which will hopefully come in Ginkgo V2, once it does, we can revert this and change the `BeforeEach` to a `BeforeAll`.

My hope is that by reducing the number of spot instances we need to spin up, this will improve the reliability of this test on Azure which seems to have some issues bringing up spot instances.

I'd suggest reviewing this with white space changes ignored, it should make a lot more sense that way 🤞 

CC @kwoodson 