### PR TITLE
Reduce failures in webhook tests

### DIFF
--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -104,8 +104,8 @@ var _ = Describe("[Feature:Operators] Machine API operator deployment should", f
 		Expect(err).NotTo(HaveOccurred())
 
 		initial, err := framework.GetMutatingWebhookConfiguration(client, framework.DefaultMutatingWebhookConfiguration.Name)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(initial).ToNot(BeNil())
-		Expect(err).To(Succeed())
 
 		toUpdate := initial.DeepCopy()
 		for _, webhook := range toUpdate.Webhooks {
@@ -118,8 +118,8 @@ var _ = Describe("[Feature:Operators] Machine API operator deployment should", f
 		Expect(framework.IsMutatingWebhookConfigurationSynced(client)).To(BeTrue())
 
 		updated, err := framework.GetMutatingWebhookConfiguration(client, framework.DefaultMutatingWebhookConfiguration.Name)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(updated).ToNot(BeNil())
-		Expect(err).To(Succeed())
 
 		for i, webhook := range updated.Webhooks {
 			Expect(webhook.ClientConfig.CABundle).To(Equal(initial.Webhooks[i].ClientConfig.CABundle))
@@ -131,8 +131,8 @@ var _ = Describe("[Feature:Operators] Machine API operator deployment should", f
 		Expect(err).NotTo(HaveOccurred())
 
 		initial, err := framework.GetValidatingWebhookConfiguration(client, framework.DefaultValidatingWebhookConfiguration.Name)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(initial).ToNot(BeNil())
-		Expect(err).To(Succeed())
 
 		toUpdate := initial.DeepCopy()
 		for _, webhook := range toUpdate.Webhooks {
@@ -145,8 +145,8 @@ var _ = Describe("[Feature:Operators] Machine API operator deployment should", f
 		Expect(framework.IsValidatingWebhookConfigurationSynced(client)).To(BeTrue())
 
 		updated, err := framework.GetValidatingWebhookConfiguration(client, framework.DefaultValidatingWebhookConfiguration.Name)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(updated).ToNot(BeNil())
-		Expect(err).To(Succeed())
 
 		for i, webhook := range updated.Webhooks {
 			Expect(webhook.ClientConfig.CABundle).To(Equal(initial.Webhooks[i].ClientConfig.CABundle))


### PR DESCRIPTION
I keep seeing the following in test failures, looks like we are checking the object before the error. Would be better to check the error first so that the error message is displayed in the JUnit output
```
/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/operators/machine-api-operator.go:129
Expected
    <*v1.ValidatingWebhookConfiguration | 0x0>: nil
not to be nil
/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/operators/machine-api-operator.go:134
```

Secondly, based on some analysis of the test results, it looks like we are not actually waiting for the object to be deleted and recreated in the recover after deletion tests.

These are the only tests that should be deleting the MWC/VWC yet looking at the must-gather for https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-api-provider-azure/158/pull-ci-openshift-cluster-api-provider-azure-master-e2e-azure-operator/1316423821439275008 shows that the MWC/VWC are recreated after the test suite ends, ie, we didn't actually wait for them to get recreated in the test.

I've added some extra checks to the tests that should check that either the MWC/VWC is gone, or that the UID has changed. Both should signify that the resource was deleted successfully. Then, and only then, is it valid to wait for the new object to be created and to be in sync with the expectations.