### PR TITLE
Wait on MachineSet replicas before waiting for nodes to go away

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -586,7 +586,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			Eventually(func() (bool, error) {
 				nodes, err := framework.GetNodesFromMachineSet(client, transientMachineSet)
 				return len(nodes) == 1, err
-			}, framework.WaitMedium, pollingInterval).Should(BeTrue())
+			}, framework.WaitLong, pollingInterval).Should(BeTrue())
 		})
 
 		It("places nodes evenly across node groups [Slow]", func() {

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -584,6 +584,14 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			// its minimum size of 1.
 			By(fmt.Sprintf("Waiting for MachineSet %s replicas to scale down", transientMachineSet.GetName()))
 			Eventually(func() (bool, error) {
+				machineSet, err := framework.GetMachineSet(client, transientMachineSet.Name)
+				if err != nil {
+					return false, err
+				}
+				return pointer.Int32PtrDerefOr(machineSet.Spec.Replicas, -1) == 1, nil
+			}, framework.WaitMedium, pollingInterval).Should(BeTrue())
+			By(fmt.Sprintf("Waiting for Deleted MachineSet %s nodes to go away", transientMachineSet.GetName()))
+			Eventually(func() (bool, error) {
 				nodes, err := framework.GetNodesFromMachineSet(client, transientMachineSet)
 				return len(nodes) == 1, err
 			}, framework.WaitLong, pollingInterval).Should(BeTrue())


### PR DESCRIPTION
This test regularly flakes. This PR extends the timeout to wait for the nodes to go away so that slower providers have more time to remove the nodes. To fail early, this also introduces a check that the replicas of the MachineSet has been reduced to 1 before waiting for the nodes to go away. If this hasn't happened within the period we can skip waiting for the longer period for the nodes to go away as we know that won't happen.

Example output from a flake:
```
/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/autoscaler/autoscaler.go:521
Timed out after 360.000s.
Error: Unexpected non-nil/non-zero extra argument at index 1:
	<*fmt.wrapError>: &fmt.wrapError{msg:"error getting node from machine \"ci-op-9i19wc9q-d57e2-t8sw7gx8g9-2l966\": nodes \"ci-op-9i19wc9q-d57e2-t8sw7gx8g9-2l966\" not found", err:(*errors.StatusError)(0xc002a43ae0)}
/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/autoscaler/autoscaler.go:589
```

CC @elmiko 