### PR TITLE
Run operator tests in serial rather than parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test-e2e: ## Run openshift specific e2e test
 	# failures and flakes.
 	# Feature:Operator tests remove deployments. Thus loosing all the logs
 	# previously acquired.
-	hack/ci-integration.sh $(GINKGO_ARGS) -p -focus="Feature:Operators" || (hack/junitmerge.sh && exit 1)
+	hack/ci-integration.sh $(GINKGO_ARGS) -focus="Feature:Operators" || (hack/junitmerge.sh && exit 1)
 	hack/ci-integration.sh $(GINKGO_ARGS) -p -skip="Feature:Operators|Autoscaler" || (hack/junitmerge.sh && exit 1)
 	# TODO: parallelise autoscaler
 	hack/ci-integration.sh $(GINKGO_ARGS) -focus="Autoscaler" || (hack/junitmerge.sh && exit 1)


### PR DESCRIPTION
We have disruptive tests in the operator suite that do not tolerate running in parallel. Disable the parallelism until we come up with a better way to run the tests in parallel. (This may not actually be possible given the types of objects we are working with)