### PR TITLE
Bug 1880738: Add Dockerfile for CI step running mahcine-api e2e tests

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,3 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 
+WORKDIR /go/src/github.com/openshift/cluster-api-actuator-pkg
+COPY . .


### PR DESCRIPTION
This Dockerfile will build e2e tests in a separate image, which will be used to run in a dedicated CI step.

Built for https://github.com/openshift/ci-tools/blob/master/CONFIGURATION.md#images

This PR unblocks https://github.com/openshift/release/pull/13838