### PR TITLE
Improve resilience of autoscaler 12 nodes total test

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -595,6 +595,11 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 				nodes, err := framework.GetNodesFromMachineSet(client, transientMachineSet)
 				return len(nodes) == 1, err
 			}, framework.WaitLong, pollingInterval).Should(BeTrue())
+			By(fmt.Sprintf("Waiting for Deleted MachineSet %s machines to go away", transientMachineSet.GetName()))
+			Eventually(func() (bool, error) {
+				machines, err := framework.GetMachinesFromMachineSet(client, transientMachineSet)
+				return len(machines) == 1, err
+			}, framework.WaitLong, pollingInterval).Should(BeTrue())
 		})
 
 		It("places nodes evenly across node groups [Slow]", func() {


### PR DESCRIPTION
This is an attempt to improve the resilience of the following test. In this case, the node had gone away but the Machine had not. We can check those two things separately. The `GetNodesFromMachineSet` helper in the framework should be ignoring the not found error, it is up to the caller to check the number is correct.

```
Machine Suite: [Feature:Machines] Autoscaler should use a ClusterAutoscaler that has 12 maximum total nodes count and balance similar nodes enabled scales up and down while respecting MaxNodesTotal [Slow][Serial] expand_less | 23m20s
-- | --
/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/autoscaler/autoscaler.go:521 Timed out after 360.001s. Error: Unexpected non-nil/non-zero extra argument at index 1: 	<*fmt.wrapError>: &fmt.wrapError{msg:"error getting node from machine \"ci-op-cr8lz3b0-d5662-pr6wdmng5s-27ltb\": nodes \"ci-op-cr8lz3b0-d5662-pr6wdmng5s-27ltb\" not found", err:(*errors.StatusError)(0xc00065c320)} /go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/autoscaler/autoscaler.go:589
```