### PR TITLE
Change minimal providerSpec for vSphere

### DIFF
--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -233,26 +233,17 @@ func minimalGCPProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, erro
 }
 
 func minimalVSphereProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, error) {
-	fullProviderSpec := &vsphere.VSphereMachineProviderSpec{}
-	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
+	providerSpec := &vsphere.VSphereMachineProviderSpec{}
+	err := json.Unmarshal(ps.Value.Raw, providerSpec)
 	if err != nil {
 		return nil, err
 	}
+	// For vSphere only these 2 fields are defaultable
+	providerSpec.UserDataSecret = nil
+	providerSpec.CredentialsSecret = nil
 	return &mapiv1.ProviderSpec{
 		Value: &runtime.RawExtension{
-			Object: &vsphere.VSphereMachineProviderSpec{
-				Template: fullProviderSpec.Template,
-				Workspace: &vsphere.Workspace{
-					Datacenter: fullProviderSpec.Workspace.Datacenter,
-					Server:     fullProviderSpec.Workspace.Server,
-				},
-				Network: vsphere.NetworkSpec{
-					Devices: fullProviderSpec.Network.Devices,
-				},
-				NumCPUs:   fullProviderSpec.NumCPUs,
-				MemoryMiB: fullProviderSpec.MemoryMiB,
-				DiskGiB:   fullProviderSpec.DiskGiB,
-			},
+			Object: providerSpec,
 		},
 	}, nil
 }


### PR DESCRIPTION
Change minimal providerSpec for vSphere. All fields in vSphere's provider spec might be required depending on installation, we can leave only secret references empty.