### PR TITLE
Bug 1913341: [OCPCLOUD-1072] Add Disruptive test selection and mark proxy tests as disruptive.

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -124,14 +124,25 @@ func LoadClientset() (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(cfg)
 }
 
-func IsStatusAvailable(client runtimeclient.Client, name string) bool {
+func WaitForStatusAvailableShort(client runtimeclient.Client, name string) bool {
+	return expectStatusAvailableIn(client, name, WaitShort)
+}
+
+func WaitForStatusAvailableMedium(client runtimeclient.Client, name string) bool {
+	return expectStatusAvailableIn(client, name, WaitMedium)
+}
+
+func WaitForStatusAvailableOverLong(client runtimeclient.Client, name string) bool {
+	return expectStatusAvailableIn(client, name, WaitOverLong)
+}
+
+func expectStatusAvailableIn(client runtimeclient.Client, name string, timeout time.Duration) bool {
 	key := types.NamespacedName{
-		Namespace: MachineAPINamespace,
-		Name:      name,
+		Name: name,
 	}
 	clusterOperator := &configv1.ClusterOperator{}
 
-	if err := wait.PollImmediate(RetryShort, WaitShort, func() (bool, error) {
+	if err := wait.PollImmediate(RetryMedium, timeout, func() (bool, error) {
 		if err := client.Get(context.TODO(), key, clusterOperator); err != nil {
 			klog.Errorf("error querying api for OperatorStatus object: %v, retrying...", err)
 			return false, nil

--- a/pkg/operators/cluster-autoscaler-operator.go
+++ b/pkg/operators/cluster-autoscaler-operator.go
@@ -92,6 +92,6 @@ var _ = Describe("[Feature:Operators] Cluster autoscaler cluster operator status
 		var err error
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(framework.IsStatusAvailable(client, "cluster-autoscaler")).To(BeTrue())
+		Expect(framework.WaitForStatusAvailableShort(client, "cluster-autoscaler")).To(BeTrue())
 	})
 })

--- a/pkg/operators/cluster-machine-approver.go
+++ b/pkg/operators/cluster-machine-approver.go
@@ -26,6 +26,6 @@ var _ = Describe("[Feature:Operators] Cluster Machine Approver Cluster Operator 
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(framework.IsStatusAvailable(client, cmaClusterOperator)).To(BeTrue())
+		Expect(framework.WaitForStatusAvailableShort(client, cmaClusterOperator)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
Proxy tests are containing some basic post condition identifying cluster as recovered.
 