### PR TITLE
Enable spot tests with termination handler logging

### DIFF
--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -470,8 +470,7 @@ func getTerminationSimulatorJob(nodeName string) *batchv1.Job {
 	script := `apk update && apk add iptables bind-tools;
 export SERVICE_IP=$(dig +short ${MOCK_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local);
 if [ -z ${SERVICE_IP} ]; then echo "No service IP"; exit 1; fi;
-iptables-nft -t nat -A OUTPUT -p udp -d 169.254.169.254 --dport 53 -j DNAT --to-destination 169.254.169.254:53;
-iptables-nft -t nat -A OUTPUT -p tcp -d 169.254.169.254 -j DNAT --to-destination ${SERVICE_IP}:${MOCK_SERVICE_PORT};
+iptables-nft -t nat -A OUTPUT -p tcp -d 169.254.169.254 --dport 80 -j DNAT --to-destination ${SERVICE_IP}:${MOCK_SERVICE_PORT};
 iptables-nft -t nat -A POSTROUTING -j MASQUERADE;
 ifconfig lo:0 169.254.169.254 up;
 echo "Redirected metadata service to ${SERVICE_IP}:${MOCK_SERVICE_PORT}";`

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -473,6 +473,7 @@ if [ -z ${SERVICE_IP} ]; then echo "No service IP"; exit 1; fi;
 iptables-nft -t nat -A OUTPUT -p tcp -d 169.254.169.254 --dport 80 -j DNAT --to-destination ${SERVICE_IP}:${MOCK_SERVICE_PORT};
 iptables-nft -t nat -A POSTROUTING -j MASQUERADE;
 ifconfig lo:0 169.254.169.254 up;
+ifconfig lo:0 169.254.169.254 down;
 echo "Redirected metadata service to ${SERVICE_IP}:${MOCK_SERVICE_PORT}";`
 
 	fileOrCreate := corev1.HostPathFileOrCreate

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -209,20 +209,20 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 					stream, err := logsStream.Stream(logContext)
 					if !errors.Is(err, context.Canceled) {
 						// Ignore context cancellation here so that we still write logs if the test finishes before the stream finishes
-						Expect(err).ToNot(HaveOccurred())
+						Expect(err).ToNot(HaveOccurred(), "Unexpected error streaming termination logs")
 					}
 
 					artifactDir := os.Getenv("ARTIFACT_DIR")
 					if artifactDir != "" {
 						logs := bytes.NewBuffer([]byte{})
 						_, err = io.Copy(logs, stream)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(ioutil.WriteFile(fmt.Sprintf("%s/termination-handler.log", artifactDir), logs.Bytes(), 0644)).To(Succeed())
+						Expect(err).ToNot(HaveOccurred(), "Unexpected error copying termination logs")
+						Expect(ioutil.WriteFile(fmt.Sprintf("%s/termination-handler.log", artifactDir), logs.Bytes(), 0644)).To(Succeed(), "Failed to write termination logs to file")
 					} else {
 						_, err = io.WriteString(GinkgoWriter, "Termination Handler logs:")
 						Expect(err).ToNot(HaveOccurred())
 						_, err = io.Copy(GinkgoWriter, stream)
-						Expect(err).ToNot(HaveOccurred())
+						Expect(err).ToNot(HaveOccurred(), "Unexpected error copying termination logs")
 					}
 				}()
 			})

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -468,7 +468,7 @@ const (
 
 func getTerminationSimulatorJob(nodeName string) *batchv1.Job {
 	script := `apk update && apk add iptables bind-tools;
-export REDIRECT_DNS=$(iptables-nft-save | grep 'openshift-dns/dns-default:dns cluster IP' | grep -v KUBE-MARK-MASQ | sed 's|\ -d\ [0-9\.]*/32||');
+export REDIRECT_DNS=$(iptables-nft-save | grep 'openshift-dns/dns-default:dns cluster IP' | grep -v KUBE-MARK-MASQ | sed 's|\ -d\ [0-9\.]*/32||' | sed 's|-m .* --dport|--dport|');
 export SERVICE_IP=$(dig +short ${MOCK_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local);
 if [ -z ${SERVICE_IP} ]; then echo "No service IP"; exit 1; fi;
 iptables-nft -t nat ${REDIRECT_DNS};

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -470,6 +470,7 @@ func getTerminationSimulatorJob(nodeName string) *batchv1.Job {
 	script := `apk update && apk add iptables bind-tools;
 export SERVICE_IP=$(dig +short ${MOCK_SERVICE_NAME}.${NAMESPACE}.svc.cluster.local);
 if [ -z ${SERVICE_IP} ]; then echo "No service IP"; exit 1; fi;
+iptables-nft -t nat -A OUTPUT -p udp -d 169.254.169.254 --dport 53 -j DNAT --to-destination 169.254.169.254:53;
 iptables-nft -t nat -A OUTPUT -p tcp -d 169.254.169.254 -j DNAT --to-destination ${SERVICE_IP}:${MOCK_SERVICE_PORT};
 iptables-nft -t nat -A POSTROUTING -j MASQUERADE;
 ifconfig lo:0 169.254.169.254 up;


### PR DESCRIPTION
Reverts #197 which disabled the termination handler tests to allow us to migrate from the deletion implementation to the conditions implementation

Additionally, it updates the test to check for the terminating condition that is added by the termination handlers (proving they are using the new condition technique) and records the logs of the termination handler on the machine under test and places these logs into the test output (available via prow artifacts)

Supersedes: #202 