### PR TITLE
Enable running autoscaler tests for Vsphere

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -307,7 +307,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			platform := clusterInfra.Status.PlatformStatus.Type
 			switch platform {
-			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType:
+			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType, configv1.VSpherePlatformType:
 				klog.Infof("Platform is %v", platform)
 			default:
 				Skip(fmt.Sprintf("Platform %v does not support autoscaling from/to zero, skipping.", platform))


### PR DESCRIPTION
This PR enables running autoscaler tests for Vsphere platfrom, since autoscaling from/to zero on Vsphere should be enabled by openshift/machine-api-operator#839.