### PR TITLE
WIP: Reduce number of replicas for machinesets(Used to investigate CI issues) 

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -307,7 +307,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			platform := clusterInfra.Status.PlatformStatus.Type
 			switch platform {
-			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType:
+			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType, configv1.VSpherePlatformType:
 				klog.Infof("Platform is %v", platform)
 			default:
 				Skip(fmt.Sprintf("Platform %v does not support autoscaling from/to zero, skipping.", platform))

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -151,7 +151,7 @@ var _ = Describe("[Feature:Machines] Managed cluster should", func() {
 		client, err = framework.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
 
-		machineSetParams = framework.BuildMachineSetParams(client, 3)
+		machineSetParams = framework.BuildMachineSetParams(client, 2)
 
 		By("Creating a new MachineSet")
 		machineSet, err = framework.CreateMachineSet(client, machineSetParams)

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -244,6 +244,7 @@ func minimalVSphereProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, 
 				Template: fullProviderSpec.Template,
 				Workspace: &vsphere.Workspace{
 					Datacenter: fullProviderSpec.Workspace.Datacenter,
+					Datastore:  fullProviderSpec.Workspace.Datastore,
 					Server:     fullProviderSpec.Workspace.Server,
 				},
 				Network: vsphere.NetworkSpec{

--- a/pkg/machinehealthcheck/machinehealthcheck.go
+++ b/pkg/machinehealthcheck/machinehealthcheck.go
@@ -20,8 +20,8 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck", func() {
 
 	var machineSet *mapiv1beta1.MachineSet
 	var machinehealthcheck *v1beta1.MachineHealthCheck
-	var maxUnhealthy = 3
-	const expectedReplicas = 5
+	var maxUnhealthy = 2
+	const expectedReplicas = 4
 
 	const E2EConditionType = "MachineHealthCheckE2E"
 


### PR DESCRIPTION
Reduce number of replicas for machineSets to ease the load on testing platforms. Mainly Vsphere. 
Also increase wait times so machines have enough time to create.

This PR is experiment.
Do not merge!  