### PR TITLE
Bug 1986990: WaitForValidatingWebhook should use v1 instead of removed v1beta1

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -2,7 +2,6 @@ package autoscaler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -291,14 +290,13 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			caName := clusterAutoscaler.GetName()
 			Expect(deleteObject(caName, cleanupObjects[caName])).Should(Succeed())
 			delete(cleanupObjects, caName)
-			Eventually(func() bool {
-				t := &apierrors.StatusError{}
-				// Convert the error to a StatusError and allow `IsNotFound` to check that.
-				// TODO drop this conversion once we have upgraded to K8s 1.19 which will support error wrapping first class.
-				if _, err := framework.GetClusterAutoscaler(client, caName); err != nil && errors.As(err, &t) && apierrors.IsNotFound(t) {
-					return true
+			Eventually(func() (bool, error) {
+				_, err := framework.GetClusterAutoscaler(client, caName)
+				if apierrors.IsNotFound(err) {
+					return true, nil
 				}
-				return false
+				// Return the error so that failures print additional errors
+				return false, err
 			}, framework.WaitMedium, pollingInterval).Should(BeTrue())
 		})
 
@@ -506,14 +504,13 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			caName := clusterAutoscaler.GetName()
 			Expect(deleteObject(caName, cleanupObjects[caName])).Should(Succeed())
 			delete(cleanupObjects, caName)
-			Eventually(func() bool {
-				t := &apierrors.StatusError{}
-				// Convert the error to a StatusError and allow `IsNotFound` to check that.
-				// TODO drop this conversion once we have upgraded to K8s 1.19 which will support error wrapping first class.
-				if _, err := framework.GetClusterAutoscaler(client, caName); err != nil && errors.As(err, &t) && apierrors.IsNotFound(t) {
-					return true
+			Eventually(func() (bool, error) {
+				_, err := framework.GetClusterAutoscaler(client, caName)
+				if apierrors.IsNotFound(err) {
+					return true, nil
 				}
-				return false
+				// Return the error so that failures print additional errors
+				return false, err
 			}, framework.WaitMedium, pollingInterval).Should(BeTrue())
 		})
 

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -6,7 +6,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -121,7 +121,7 @@ func expectStatusAvailableIn(client runtimeclient.Client, name string, timeout t
 
 func WaitForValidatingWebhook(client runtimeclient.Client, name string) bool {
 	key := types.NamespacedName{Name: name}
-	webhook := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{}
+	webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{}
 
 	if err := wait.PollImmediate(RetryShort, WaitShort, func() (bool, error) {
 		if err := client.Get(context.TODO(), key, webhook); err != nil {


### PR DESCRIPTION
Based on the test results of #202, v1beta1 has been removed, and as such, this test is now perma-failing. Moving to v1 should resolve the issue.
```
E0712 08:41:39.099087   12407 framework.go:128] error querying api for ValidatingWebhookConfiguration: no matches for kind "ValidatingWebhookConfiguration" in version "admissionregistration.k8s.io/v1beta1", retrying...
```