### PR TITLE
Bug 1989051: Do not set spot max price if empty

### DIFF
--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -218,8 +218,9 @@ func setSpotOnAWSProviderSpec(params framework.MachineSetParams, maxPrice string
 		return fmt.Errorf("error unmarshalling providerspec: %v", err)
 	}
 
-	spec.SpotMarketOptions = &awsproviderconfigv1.SpotMarketOptions{
-		MaxPrice: &maxPrice,
+	spec.SpotMarketOptions = &awsproviderconfigv1.SpotMarketOptions{}
+	if maxPrice != "" {
+		spec.SpotMarketOptions.MaxPrice = &maxPrice
 	}
 
 	params.ProviderSpec.Value.Raw, err = json.Marshal(spec)
@@ -237,8 +238,9 @@ func setSpotOnAzureProviderSpec(params framework.MachineSetParams, maxPrice stri
 		return fmt.Errorf("error unmarshalling providerspec: %v", err)
 	}
 
-	spec.SpotVMOptions = &azureproviderconfigv1.SpotVMOptions{
-		MaxPrice: &maxPrice,
+	spec.SpotVMOptions = &azureproviderconfigv1.SpotVMOptions{}
+	if maxPrice != "" {
+		spec.SpotVMOptions.MaxPrice = &maxPrice
 	}
 
 	params.ProviderSpec.Value.Raw, err = json.Marshal(spec)


### PR DESCRIPTION
Spot tests are currently broken when the spot price is set to the empty string, let's not set the spot price if it's empty.

```
Machine error: failed to create machine "ci-op-xjhkjx76-d57e2-75kbmvgjwn-b85rl" scope: error unmarshaling JSON: while decoding JSON: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'%!(EXTRA string=failed to get machine config)
```

