### PR TITLE
This is a test.

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -301,6 +301,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 		})
 
 		It("It scales from/to zero", func() {
+			panic("Will this panic happen in the rehearsals?")
 			// Only run in platforms which support autoscaling from/to zero.
 			clusterInfra, err := framework.GetInfrastructure(client)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
I add a panic in the test code, and see if it happens in the presubmit
jobs. With this test I want to understand why the "from/to zero" tests
do not happen for OpenStack in this PR:
https://github.com/openshift/cluster-api-actuator-pkg/pull/191