### PR TITLE
Replace docker hub image with registry image in rc controller

### DIFF
--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -49,7 +49,7 @@ func replicationControllerWorkload(namespace string) *corev1.ReplicationControll
 					Containers: []corev1.Container{
 						{
 							Name:    "work",
-							Image:   "busybox",
+							Image:   "registry.ci.openshift.org/openshift/origin-v4.0:base",
 							Command: []string{"sleep", "10h"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{


### PR DESCRIPTION
We keep seeing tests using this replication controller fail because of image pull back off issues for the `busybox` image. This is likely because the docker hub image is being rate limited in CI.

eg The following error is consistent across all pods on [this CI run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-api-actuator-pkg/203/pull-ci-openshift-cluster-api-actuator-pkg-master-e2e-vsphere-operator/1457737345141837824)
```
"state": {
[10]           "waiting": {
[10]             "reason": "ImagePullBackOff",
[10]             "message": "Back-off pulling image \"busybox\""
[10]           }
[10]         },
```

By using a registry.ci image we won't have issues with pull limits in the future