### PR TITLE
Bug 2060068: add security groups to the minimal AWS prover spec

### DIFF
--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -188,6 +188,7 @@ func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec
 				Placement:          fullProviderSpec.Placement,
 				Subnet:             *fullProviderSpec.Subnet.DeepCopy(),
 				IAMInstanceProfile: fullProviderSpec.IAMInstanceProfile.DeepCopy(),
+				SecurityGroups:     fullProviderSpec.SecurityGroups,
 			},
 		},
 	}, nil


### PR DESCRIPTION
We are going to make this field mandatore in the spec, so tests must specify it.