### PR TITLE
Bug 2097607: Add Powervs support for Webhook tests

### DIFF
--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -70,9 +70,10 @@ var _ = BeforeSuite(func() {
 
 	// Extend timeouts for slower providers
 	switch platform {
-	case osconfigv1.AzurePlatformType, osconfigv1.VSpherePlatformType, osconfigv1.OpenStackPlatformType:
+	case osconfigv1.AzurePlatformType, osconfigv1.VSpherePlatformType, osconfigv1.OpenStackPlatformType, osconfigv1.PowerVSPlatformType:
 		framework.WaitShort = 2 * time.Minute  // Normally 1m
 		framework.WaitMedium = 6 * time.Minute // Normally 3m
 		framework.WaitLong = 30 * time.Minute  // Normally 15m
+
 	}
 })

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
-	machinev1 "github.com/openshift/api/machine/v1beta1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,13 +64,13 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 
 	It("should be able to create a machine from a minimal providerSpec", func() {
-		machine := &machinev1.Machine{
+		machine := &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-webhook-", machineSetParams.Name),
 				Namespace:    framework.MachineAPINamespace,
 				Labels:       machineSetParams.Labels,
 			},
-			Spec: machinev1.MachineSpec{
+			Spec: machinev1beta1.MachineSpec{
 				ProviderSpec: *machineSetParams.ProviderSpec,
 			},
 		}
@@ -81,7 +81,7 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 			if err != nil {
 				return err
 			}
-			running := framework.FilterRunningMachines([]*machinev1.Machine{m})
+			running := framework.FilterRunningMachines([]*machinev1beta1.Machine{m})
 			if len(running) == 0 {
 				return fmt.Errorf("machine not yet running")
 			}
@@ -97,13 +97,13 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 
 	It("should return an error when removing required fields from the Machine providerSpec", func() {
-		machine := &machinev1.Machine{
+		machine := &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-webhook-", machineSetParams.Name),
 				Namespace:    framework.MachineAPINamespace,
 				Labels:       machineSetParams.Labels,
 			},
-			Spec: machinev1.MachineSpec{
+			Spec: machinev1beta1.MachineSpec{
 				ProviderSpec: *machineSetParams.ProviderSpec,
 			},
 		}
@@ -159,7 +159,7 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 })
 
-func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
+func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
 	switch platform {
 	case configv1.AWSPlatformType:
 		return minimalAWSProviderSpec(ps)
@@ -175,15 +175,15 @@ func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1.Pro
 	}
 }
 
-func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
-	fullProviderSpec := &machinev1.AWSMachineProviderConfig{}
+func minimalAWSProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
+	fullProviderSpec := &machinev1beta1.AWSMachineProviderConfig{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
-			Object: &machinev1.AWSMachineProviderConfig{
+			Object: &machinev1beta1.AWSMachineProviderConfig{
 				AMI:                fullProviderSpec.AMI,
 				Placement:          fullProviderSpec.Placement,
 				Subnet:             *fullProviderSpec.Subnet.DeepCopy(),
@@ -193,17 +193,17 @@ func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec
 	}, nil
 }
 
-func minimalAzureProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
-	fullProviderSpec := &machinev1.AzureMachineProviderSpec{}
+func minimalAzureProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
+	fullProviderSpec := &machinev1beta1.AzureMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
-			Object: &machinev1.AzureMachineProviderSpec{
+			Object: &machinev1beta1.AzureMachineProviderSpec{
 				Location: fullProviderSpec.Location,
-				OSDisk: machinev1.OSDisk{
+				OSDisk: machinev1beta1.OSDisk{
 					DiskSizeGB: fullProviderSpec.OSDisk.DiskSizeGB,
 				},
 			},
@@ -211,15 +211,15 @@ func minimalAzureProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSp
 	}, nil
 }
 
-func minimalGCPProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
-	fullProviderSpec := &machinev1.GCPMachineProviderSpec{}
+func minimalGCPProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
+	fullProviderSpec := &machinev1beta1.GCPMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
-			Object: &machinev1.GCPMachineProviderSpec{
+			Object: &machinev1beta1.GCPMachineProviderSpec{
 				Region:          fullProviderSpec.Region,
 				Zone:            fullProviderSpec.Zone,
 				ServiceAccounts: fullProviderSpec.ServiceAccounts,
@@ -228,8 +228,8 @@ func minimalGCPProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec
 	}, nil
 }
 
-func minimalVSphereProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
-	providerSpec := &machinev1.VSphereMachineProviderSpec{}
+func minimalVSphereProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
+	providerSpec := &machinev1beta1.VSphereMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, providerSpec)
 	if err != nil {
 		return nil, err
@@ -237,7 +237,7 @@ func minimalVSphereProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.Provider
 	// For vSphere only these 2 fields are defaultable
 	providerSpec.UserDataSecret = nil
 	providerSpec.CredentialsSecret = nil
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: providerSpec,
 		},


### PR DESCRIPTION
Recently we have added webhooks for Power VS in mapio with the [PR](https://github.com/openshift/machine-api-operator/pull/998), So in this PR adding support for Power VS in Webhook tests