### PR TITLE
Bug 2106403: Add Nutanix as the supported provider platform for e2e-nutanix-operator test

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -254,7 +254,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			platform := clusterInfra.Status.PlatformStatus.Type
 			switch platform {
-			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType, configv1.VSpherePlatformType:
+			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType, configv1.VSpherePlatformType, configv1.NutanixPlatformType:
 				klog.Infof("Platform is %v", platform)
 			default:
 				Skip(fmt.Sprintf("Platform %v does not support autoscaling from/to zero, skipping.", platform))

--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 
 	// Extend timeouts for slower providers
 	switch platform {
-	case osconfigv1.AzurePlatformType, osconfigv1.VSpherePlatformType, osconfigv1.OpenStackPlatformType, osconfigv1.PowerVSPlatformType:
+	case osconfigv1.AzurePlatformType, osconfigv1.VSpherePlatformType, osconfigv1.OpenStackPlatformType, osconfigv1.PowerVSPlatformType, osconfigv1.NutanixPlatformType:
 		framework.WaitShort = 2 * time.Minute  // Normally 1m
 		framework.WaitMedium = 6 * time.Minute // Normally 3m
 		framework.WaitLong = 30 * time.Minute  // Normally 15m


### PR DESCRIPTION
After adding the Machine CR defaulter and validator webhooks for Nutanix platform (openshift/machine-api-operator repo PRs #1034, #1038), we need to add Nutanix as the supported platform in the "Webhooks" test cases of the cluster-api-actuator-pkg repo, for the e2e-nutanix-operator test run to pass.