### PR TITLE
add failed machine detection to WaitForMachineSets

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -31,6 +31,7 @@ const (
 	// if MachineSet.Spec.Replicas field is set to nil
 	DefaultMachineSetReplicas = 0
 	MachinePhaseRunning       = "Running"
+	MachinePhaseFailed        = "Failed"
 	MachineRoleLabel          = "machine.openshift.io/cluster-api-machine-role"
 	MachineTypeLabel          = "machine.openshift.io/cluster-api-machine-type"
 	MachineAnnotationKey      = "machine.openshift.io/machine"

--- a/pkg/framework/machines.go
+++ b/pkg/framework/machines.go
@@ -19,18 +19,24 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// FilterRunningMachines returns a slice of only those Machines in the input
-// that are in the "Running" phase.
-func FilterRunningMachines(machines []*machinev1.Machine) []*machinev1.Machine {
+// FilterMachines returns a slice of only those Machines in the input that are
+// in the requested phase.
+func FilterMachines(machines []*machinev1.Machine, phase string) []*machinev1.Machine {
 	var result []*machinev1.Machine
 
 	for i, m := range machines {
-		if m.Status.Phase != nil && *m.Status.Phase == MachinePhaseRunning {
+		if m.Status.Phase != nil && *m.Status.Phase == phase {
 			result = append(result, machines[i])
 		}
 	}
 
 	return result
+}
+
+// FilterRunningMachines returns a slice of only those Machines in the input
+// that are in the "Running" phase.
+func FilterRunningMachines(machines []*machinev1.Machine) []*machinev1.Machine {
+	return FilterMachines(machines, MachinePhaseRunning)
 }
 
 // GetMachine get a machine by its name from the default machine API namespace.


### PR DESCRIPTION
this change makes it so that any test using WaitForMachineSets will exit
if any of the machines come up in failed phase. it will print the failed
machines and exit the test.