### PR TITLE
Ensure proxy test pods run in privileged namespace

### DIFF
--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -15,12 +15,11 @@ import (
 )
 
 const proxySetup = `
-cd /root
-mkdir /root/.mitmproxy
-cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem
+cd /.mitmproxy
+cat /root/certs/tls.key /root/certs/tls.crt > /.mitmproxy/mitmproxy-ca.pem
 curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
 tar xvf mitmproxy-5.3.0-linux.tar.gz
-./mitmdump
+HOME=/.mitmproxy ./mitmdump
 `
 
 const mitmSignerCert = `
@@ -144,6 +143,12 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 								},
 							},
 						},
+						{
+							Name: "mitm-workdir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -166,6 +171,11 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 									Name:      "mitm-signer",
 									ReadOnly:  false,
 									MountPath: "/root/certs",
+								},
+								{
+									Name:      "mitm-workdir",
+									ReadOnly:  false,
+									MountPath: "/.mitmproxy",
 								},
 							},
 						},

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -16,10 +16,10 @@ import (
 const proxySetup = `
 cd /root
 mkdir /root/.mitmproxy
-cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem  
+cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem
 curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
 tar xvf mitmproxy-5.3.0-linux.tar.gz
-./mitmdump 
+./mitmdump
 `
 
 const mitmSignerCert = `
@@ -65,14 +65,14 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      "mitm-proxy",
-		Namespace: "default",
+		Namespace: MachineAPINamespace,
 		Labels:    mitmDeploymentLabels,
 	}
 
 	mitmSigner := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-signer",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 			Labels:    mitmDeploymentLabels,
 		},
 		Data: map[string][]byte{
@@ -87,7 +87,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	mitmBootstrapConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-bootstrap",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 		Data: map[string]string{
 			"startup.sh": proxySetup,
@@ -178,7 +178,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 		return err
 	}
 
-	IsDaemonsetAvailable(c, "mitm-proxy", "default")
+	IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace)
 
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
@@ -199,7 +199,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	if err != nil {
 		return err
 	}
-	IsServiceAvailable(c, "mitm-proxy", "default")
+	IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace)
 
 	return err
 }
@@ -212,14 +212,14 @@ func DestroyClusterProxy(c runtimeclient.Client) error {
 
 	mitmObjectMeta := metav1.ObjectMeta{
 		Name:      "mitm-proxy",
-		Namespace: "default",
+		Namespace: MachineAPINamespace,
 		Labels:    mitmDeploymentLabels,
 	}
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-bootstrap",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 	}
 	err := c.Delete(context.Background(), configMap)
@@ -241,7 +241,7 @@ func DestroyClusterProxy(c runtimeclient.Client) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-signer",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 	}
 	err = c.Delete(context.Background(), secret)

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -178,7 +179,9 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 		return err
 	}
 
-	IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace)
+	if !IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace) {
+		return errors.New("daemonset did not become available")
+	}
 
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
@@ -199,7 +202,9 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	if err != nil {
 		return err
 	}
-	IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace)
+	if !IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace) {
+		return errors.New("service did not become available")
+	}
 
 	return err
 }

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -253,9 +253,6 @@ var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide prox
 
 		By("waiting for machine-api-controller deployment to reflect unconfigured cluster-wide proxy")
 		Expect(framework.WaitForProxyInjectionSync(client, maoManagedDeployment, framework.MachineAPINamespace, false)).To(BeTrue())
-
-		err = framework.DestroyClusterProxy(client)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -270,5 +267,8 @@ var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide prox
 		By("waiting for KCM cluster operator to become available")
 		Expect(framework.WaitForStatusAvailableOverLong(client, "kube-controller-manager")).To(BeTrue())
 		Expect(framework.WaitForStatusAvailableMedium(client, "machine-api")).To(BeTrue())
+
+		By("Removing the mitm-proxy")
+		Expect(framework.DestroyClusterProxy(client)).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
This test is currently not working as expected (and also not failing?) as the mitm-proxy daemonset was being deployed to the default namespace.

If instead we deploy to our own namespace, we don't need to worry about the pod security admission policy and can fix the tests for the short term.

In the long term we will want to work out how to reduce these privileges and remove the need for the privileged namespace