### PR TITLE
Wait for Machines to be deleted before completeing each test case

### DIFF
--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -398,15 +398,16 @@ func WaitForMachineSetsDeleted(c runtimeclient.Client, machineSets ...*machinev1
 				return fmt.Errorf("%d Machines still present for MachineSet %s", len(machines), ms.GetName())
 			}
 
-			if err := c.Get(context.Background(), runtimeclient.ObjectKey{
+			machineSetErr := c.Get(context.Background(), runtimeclient.ObjectKey{
 				Name:      ms.GetName(),
 				Namespace: ms.GetNamespace(),
-			}, &machinev1.MachineSet{}); err != nil && !apierrors.IsNotFound(err) {
+			}, &machinev1.MachineSet{})
+			if machineSetErr != nil && !apierrors.IsNotFound(machineSetErr) {
 				return fmt.Errorf("could not fetch MachineSet %s: %v", ms.GetName(), err)
 			}
 
 			// No error means the MachineSet still exists.
-			if err == nil {
+			if machineSetErr == nil {
 				return fmt.Errorf("MachineSet %s still present, but has no Machines", ms.GetName())
 			}
 

--- a/pkg/infra/lifecyclehooks.go
+++ b/pkg/infra/lifecyclehooks.go
@@ -75,6 +75,10 @@ var _ = Describe("[Feature:Machine] Lifecycle Hooks should", func() {
 		Expect(client.Delete(context.Background(), machineSet, &runtimeclient.DeleteOptions{
 			PropagationPolicy: &cascadeDelete,
 		})).To(Succeed())
+
+		By("Waiting for the MachineSet to be deleted...")
+		framework.WaitForMachineSetDelete(client, machineSet)
+
 		By("Deleting workload job")
 		Expect(client.Delete(context.Background(), workload, &runtimeclient.DeleteOptions{
 			PropagationPolicy: &cascadeDelete,

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -73,7 +73,24 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 	})
 
 	AfterEach(func() {
-		Expect(deleteObjects(client, delObjects)).To(Succeed())
+		var machineSets []*machinev1.MachineSet
+
+		for _, obj := range delObjects {
+			if machineSet, ok := obj.(*machinev1.MachineSet); ok {
+				// Once we delete a MachineSet we should make sure that the
+				// all of its machines are deleted as well.
+				// Collect MachineSets to wait for.
+				machineSets = append(machineSets, machineSet)
+			}
+
+			Expect(deleteObject(client, obj)).To(Succeed())
+		}
+
+		if len(machineSets) > 0 {
+			// Wait for all MachineSets and their Machines to be deleted.
+			By("Waiting for MachineSets to be deleted...")
+			framework.WaitForMachineSetsDeleted(client, machineSets...)
+		}
 	})
 
 	It("should handle the spot instances", func() {

--- a/pkg/providers/aws.go
+++ b/pkg/providers/aws.go
@@ -39,6 +39,8 @@ var _ = Describe("[Feature:Machines] [AWS] MetadataServiceOptions", func() {
 	AfterEach(func() {
 		Expect(framework.DeleteMachineSets(client, toDelete...)).To(Succeed())
 		toDelete = make([]*machinev1.MachineSet, 0, 3)
+
+		framework.WaitForMachineSetsDeleted(client, toDelete...)
 	})
 
 	createMachineSet := func(metadataAuth string) (*machinev1.MachineSet, error) {


### PR DESCRIPTION
@elmiko recently reported that he was seeing cordoned Machines interfering with tests in the autoscaler suite. When running the suite against a test cluster I observed that MachineSets were deleted but the suite moved onto new tests before the old Machines had gone away.

When writing tests we should always make sure we leave the environment clean _before_ we declare the test finished.

This PR adds ensures that every test we have that creates a MachineSet, has a `WaitForMachineSetsDeleted` call in an after each when the test finishes. This helper looks for Machines owned by the MachineSet and only finishes successfully once all of those Machines have gone away.

This should ensure we lave the Machine state clean after these tests.