### PR TITLE
Disable spot instance tests until further notice

### DIFF
--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -43,12 +43,16 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 		var err error
 		client, err = framework.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
-		// Only run on AWS
+
 		platform, err = framework.GetPlatform(client)
 		Expect(err).NotTo(HaveOccurred())
 		switch platform {
 		case configv1.AWSPlatformType, configv1.AzurePlatformType:
-			// Do Nothing
+			// The failure rate of this test has increased significantly on Azure and AWS.
+			// We are seeing a massive spike in not being able to create instances due to
+			// a lack of capacity on the platform.
+			// Skip the test until we have time to work out how to mitigate this.
+			Skip("This test has a high failure rate, skipping until further notice")
 		case configv1.GCPPlatformType:
 			// TODO: GCP relies on the metadata IP for DNS.
 			// This test prevents it from accessing the DNS, therefore


### PR DESCRIPTION
The failure rate of this test has increased significantly on Azure and AWS. We are seeing a massive spike in not being able to create instances due to a lack of capacity on the platform. Skip the test until we have time to work out how to mitigate this.

In the future we will want to do something along the lines of:
* Try different instance types if we cannot get capacity
* Try different availability zones if we cannot get capacity

To make this easier, we should make sure that capacity failures appear on the status of Machines on both AWS and Azure.
Currently on AWS an error is logged as this is a 500 error, but it does not end up on the status. We will want to interpret the error and be smarter about reporting this condition.

Tracking card for re-enabling this test: https://issues.redhat.com/browse/OCPCLOUD-1733