### PR TITLE
OCPCLOUD-1757: release-4.11, backport various improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
 	  -e "GO111MODULE=$(GO111MODULE)" \
 	  -e "GOFLAGS=$(GOFLAGS)" \
 	  -e "GOPROXY=$(GOPROXY)" \
-	  openshift/origin-release:golang-1.18
+	  registry.ci.openshift.org/openshift/release:golang-1.18
   IMAGE_BUILD_CMD = $(ENGINE) build
 endif
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -46,7 +46,7 @@ func clusterAutoscalerResource(maxNodesTotal int) *caov1.ClusterAutoscaler {
 	// and that has high least common multiple to avoid a case
 	// when a node is considered to be empty even if there are
 	// pods already scheduled and running on the node.
-	unneededTimeString := "23s"
+	unneededTimeString := "60s"
 	return &caov1.ClusterAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -293,8 +293,9 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			Expect(client.Create(ctx, asr)).Should(Succeed())
 			cleanupObjects[asr.GetName()] = asr
 
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s", expectedReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(expectedReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-scale-from-zero", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s", uniqueJobName, expectedReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(expectedReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -353,9 +354,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			}
 
 			jobReplicas := expectedReplicas * int32(2)
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
-				jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-cleanup-after-scale-down", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -506,9 +508,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			// to the maximum MachineSet size this will create enough demand to
 			// grow the cluster to maximum size.
 			jobReplicas := maxMachineSetReplicas
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
-				jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-scale-to-maxnodestotal", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -605,9 +608,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			// expand its size by 2 nodes. the cluster autoscaler should
 			// place 1 node in each of the 2 MachineSets created.
 			jobReplicas := int32(4)
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
-				jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-balance-nodegroups", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -514,9 +514,12 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			// At this point the autoscaler should be growing the cluster, we
 			// wait until the cluster has grown to reach MaxNodesTotal size.
+			// Because the autoscaler will ignore nodes that are not ready or unschedulable,
+			// we need to check against the number of ready nodes in the cluster since
+			// previous tests might have left nodes that are not ready or unschedulable.
 			By(fmt.Sprintf("Waiting for cluster to scale up to %d nodes", caMaxNodesTotal))
 			Eventually(func() (bool, error) {
-				nodes, err := framework.GetNodes(client)
+				nodes, err := framework.GetReadyAndSchedulableNodes(client)
 				return len(nodes) == caMaxNodesTotal, err
 			}, framework.WaitLong, pollingInterval).Should(BeTrue())
 
@@ -528,9 +531,12 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			// Now that the cluster has reached maximum size, we want to ensure
 			// that it doesn't try to grow larger.
+			// Because the autoscaler will ignore nodes that are not ready or unschedulable,
+			// we need to check against the number of ready nodes in the cluster since
+			// previous tests might have left nodes that are not ready or unschedulable.
 			By("Watching Cluster node count to ensure it remains consistent")
 			Consistently(func() (bool, error) {
-				nodes, err := framework.GetNodes(client)
+				nodes, err := framework.GetReadyAndSchedulableNodes(client)
 				return len(nodes) == caMaxNodesTotal, err
 			}, framework.WaitShort, pollingInterval).Should(BeTrue())
 

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -29,12 +29,13 @@ const (
 	RetryMedium             = 5 * time.Second
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil
-	DefaultMachineSetReplicas = 0
-	MachinePhaseRunning       = "Running"
-	MachinePhaseFailed        = "Failed"
-	MachineRoleLabel          = "machine.openshift.io/cluster-api-machine-role"
-	MachineTypeLabel          = "machine.openshift.io/cluster-api-machine-type"
-	MachineAnnotationKey      = "machine.openshift.io/machine"
+	DefaultMachineSetReplicas  = 0
+	MachinePhaseRunning        = "Running"
+	MachinePhaseFailed         = "Failed"
+	MachineRoleLabel           = "machine.openshift.io/cluster-api-machine-role"
+	MachineTypeLabel           = "machine.openshift.io/cluster-api-machine-type"
+	MachineAnnotationKey       = "machine.openshift.io/machine"
+	ClusterAPIActuatorPkgTaint = "cluster-api-actuator-pkg"
 )
 
 var (

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -31,6 +31,7 @@ const (
 	// if MachineSet.Spec.Replicas field is set to nil
 	DefaultMachineSetReplicas = 0
 	MachinePhaseRunning       = "Running"
+	MachinePhaseFailed        = "Failed"
 	MachineRoleLabel          = "machine.openshift.io/cluster-api-machine-role"
 	MachineTypeLabel          = "machine.openshift.io/cluster-api-machine-type"
 	MachineAnnotationKey      = "machine.openshift.io/machine"

--- a/pkg/framework/jobs.go
+++ b/pkg/framework/jobs.go
@@ -41,6 +41,10 @@ func NewWorkLoad(njobs int32, memoryRequest resource.Quantity, workloadJobName s
 							Key:      "kubemark",
 							Operator: corev1.TolerationOpExists,
 						},
+						{
+							Key:    ClusterAPIActuatorPkgTaint,
+							Effect: corev1.TaintEffectPreferNoSchedule,
+						},
 					},
 				},
 			},

--- a/pkg/framework/jobs.go
+++ b/pkg/framework/jobs.go
@@ -13,7 +13,7 @@ func NewWorkLoad(njobs int32, memoryRequest resource.Quantity, workloadJobName s
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workloadJobName,
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 			Labels:    map[string]string{testLabel: ""},
 		},
 		Spec: batchv1.JobSpec{

--- a/pkg/framework/machines.go
+++ b/pkg/framework/machines.go
@@ -19,18 +19,24 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// FilterRunningMachines returns a slice of only those Machines in the input
-// that are in the "Running" phase.
-func FilterRunningMachines(machines []*machinev1.Machine) []*machinev1.Machine {
+// FilterMachines returns a slice of only those Machines in the input that are
+// in the requested phase.
+func FilterMachines(machines []*machinev1.Machine, phase string) []*machinev1.Machine {
 	var result []*machinev1.Machine
 
 	for i, m := range machines {
-		if m.Status.Phase != nil && *m.Status.Phase == MachinePhaseRunning {
+		if m.Status.Phase != nil && *m.Status.Phase == phase {
 			result = append(result, machines[i])
 		}
 	}
 
 	return result
+}
+
+// FilterRunningMachines returns a slice of only those Machines in the input
+// that are in the "Running" phase.
+func FilterRunningMachines(machines []*machinev1.Machine) []*machinev1.Machine {
+	return FilterMachines(machines, MachinePhaseRunning)
 }
 
 // GetMachine get a machine by its name from the default machine API namespace.

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	machinev1 "github.com/openshift/api/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,6 +29,7 @@ type MachineSetParams struct {
 	Name         string
 	Replicas     int32
 	Labels       map[string]string
+	Taints       []corev1.Taint
 	ProviderSpec *machinev1.ProviderSpec
 }
 
@@ -59,6 +61,12 @@ func BuildMachineSetParams(client runtimeclient.Client, replicas int) MachineSet
 			"e2e.openshift.io": uid.String(),
 			ClusterKey:         clusterName,
 		},
+		Taints: []corev1.Taint{
+			corev1.Taint{
+				Key:    ClusterAPIActuatorPkgTaint,
+				Effect: corev1.TaintEffectPreferNoSchedule,
+			},
+		},
 	}
 }
 
@@ -87,6 +95,7 @@ func CreateMachineSet(c client.Client, params MachineSetParams) (*machinev1.Mach
 						Labels: params.Labels,
 					},
 					ProviderSpec: *params.ProviderSpec,
+					Taints:       params.Taints,
 				},
 			},
 			Replicas: pointer.Int32Ptr(params.Replicas),

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -398,15 +398,16 @@ func WaitForMachineSetsDeleted(c runtimeclient.Client, machineSets ...*machinev1
 				return fmt.Errorf("%d Machines still present for MachineSet %s", len(machines), ms.GetName())
 			}
 
-			if err := c.Get(context.Background(), runtimeclient.ObjectKey{
+			machineSetErr := c.Get(context.Background(), runtimeclient.ObjectKey{
 				Name:      ms.GetName(),
 				Namespace: ms.GetNamespace(),
-			}, &machinev1.MachineSet{}); err != nil && !apierrors.IsNotFound(err) {
+			}, &machinev1.MachineSet{})
+			if machineSetErr != nil && !apierrors.IsNotFound(machineSetErr) {
 				return fmt.Errorf("could not fetch MachineSet %s: %v", ms.GetName(), err)
 			}
 
 			// No error means the MachineSet still exists.
-			if err == nil {
+			if machineSetErr == nil {
 				return fmt.Errorf("MachineSet %s still present, but has no Machines", ms.GetName())
 			}
 

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -15,12 +15,11 @@ import (
 )
 
 const proxySetup = `
-cd /root
-mkdir /root/.mitmproxy
-cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem
+cd /.mitmproxy
+cat /root/certs/tls.key /root/certs/tls.crt > /.mitmproxy/mitmproxy-ca.pem
 curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
 tar xvf mitmproxy-5.3.0-linux.tar.gz
-./mitmdump
+HOME=/.mitmproxy ./mitmdump
 `
 
 const mitmSignerCert = `
@@ -144,6 +143,12 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 								},
 							},
 						},
+						{
+							Name: "mitm-workdir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -166,6 +171,11 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 									Name:      "mitm-signer",
 									ReadOnly:  false,
 									MountPath: "/root/certs",
+								},
+								{
+									Name:      "mitm-workdir",
+									ReadOnly:  false,
+									MountPath: "/.mitmproxy",
 								},
 							},
 						},

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -16,10 +16,10 @@ import (
 const proxySetup = `
 cd /root
 mkdir /root/.mitmproxy
-cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem  
+cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem
 curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
 tar xvf mitmproxy-5.3.0-linux.tar.gz
-./mitmdump 
+./mitmdump
 `
 
 const mitmSignerCert = `
@@ -65,14 +65,14 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      "mitm-proxy",
-		Namespace: "default",
+		Namespace: MachineAPINamespace,
 		Labels:    mitmDeploymentLabels,
 	}
 
 	mitmSigner := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-signer",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 			Labels:    mitmDeploymentLabels,
 		},
 		Data: map[string][]byte{
@@ -87,7 +87,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	mitmBootstrapConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-bootstrap",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 		Data: map[string]string{
 			"startup.sh": proxySetup,
@@ -178,7 +178,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 		return err
 	}
 
-	IsDaemonsetAvailable(c, "mitm-proxy", "default")
+	IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace)
 
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
@@ -199,7 +199,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	if err != nil {
 		return err
 	}
-	IsServiceAvailable(c, "mitm-proxy", "default")
+	IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace)
 
 	return err
 }
@@ -212,14 +212,14 @@ func DestroyClusterProxy(c runtimeclient.Client) error {
 
 	mitmObjectMeta := metav1.ObjectMeta{
 		Name:      "mitm-proxy",
-		Namespace: "default",
+		Namespace: MachineAPINamespace,
 		Labels:    mitmDeploymentLabels,
 	}
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-bootstrap",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 	}
 	err := c.Delete(context.Background(), configMap)
@@ -241,7 +241,7 @@ func DestroyClusterProxy(c runtimeclient.Client) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-signer",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 	}
 	err = c.Delete(context.Background(), secret)

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -178,7 +179,9 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 		return err
 	}
 
-	IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace)
+	if !IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace) {
+		return errors.New("daemonset did not become available")
+	}
 
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
@@ -199,7 +202,9 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	if err != nil {
 		return err
 	}
-	IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace)
+	if !IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace) {
+		return errors.New("service did not become available")
+	}
 
 	return err
 }

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -289,13 +289,18 @@ var _ = Describe("[Feature:Machines] Managed cluster should", func() {
 		}()
 
 		By("Creating RC with workload")
-		rc := replicationControllerWorkload("default")
+
+		// Use the openshift-machine-api namespace as it is excluded from
+		// Pod security admission checks.
+		namespace := framework.MachineAPINamespace
+
+		rc := replicationControllerWorkload(namespace)
 		err = client.Create(context.TODO(), rc)
 		Expect(err).NotTo(HaveOccurred())
 		delObjects["rc"] = rc
 
 		By("Creating PDB for RC")
-		pdb := podDisruptionBudget("default")
+		pdb := podDisruptionBudget(namespace)
 		err = client.Create(context.TODO(), pdb)
 		Expect(err).NotTo(HaveOccurred())
 		delObjects["pdb"] = pdb

--- a/pkg/infra/lifecyclehooks.go
+++ b/pkg/infra/lifecyclehooks.go
@@ -75,6 +75,10 @@ var _ = Describe("[Feature:Machine] Lifecycle Hooks should", func() {
 		Expect(client.Delete(context.Background(), machineSet, &runtimeclient.DeleteOptions{
 			PropagationPolicy: &cascadeDelete,
 		})).To(Succeed())
+
+		By("Waiting for the MachineSet to be deleted...")
+		framework.WaitForMachineSetDelete(client, machineSet)
+
 		By("Deleting workload job")
 		Expect(client.Delete(context.Background(), workload, &runtimeclient.DeleteOptions{
 			PropagationPolicy: &cascadeDelete,

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -43,12 +43,16 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 		var err error
 		client, err = framework.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
-		// Only run on AWS
+
 		platform, err = framework.GetPlatform(client)
 		Expect(err).NotTo(HaveOccurred())
 		switch platform {
 		case configv1.AWSPlatformType, configv1.AzurePlatformType:
-			// Do Nothing
+			// The failure rate of this test has increased significantly on Azure and AWS.
+			// We are seeing a massive spike in not being able to create instances due to
+			// a lack of capacity on the platform.
+			// Skip the test until we have time to work out how to mitigate this.
+			Skip("This test has a high failure rate, skipping until further notice")
 		case configv1.GCPPlatformType:
 			// TODO: GCP relies on the metadata IP for DNS.
 			// This test prevents it from accessing the DNS, therefore

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -51,6 +51,16 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 		testSelector = &metav1.LabelSelector{
 			MatchLabels: machineSetParams.Labels,
 		}
+
+		By("Checking the webhook configurations are synced", func() {
+			Eventually(func() bool {
+				return framework.IsMutatingWebhookConfigurationSynced(client)
+			}, framework.WaitShort).Should(BeTrue(), "MutatingWebhookConfiguration must be synced before running these tests")
+
+			Eventually(func() bool {
+				return framework.IsValidatingWebhookConfigurationSynced(client)
+			}, framework.WaitShort).Should(BeTrue(), "ValidingWebhookConfiguration must be synced before running these tests")
+		})
 	})
 
 	AfterEach(func() {

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -253,9 +253,6 @@ var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide prox
 
 		By("waiting for machine-api-controller deployment to reflect unconfigured cluster-wide proxy")
 		Expect(framework.WaitForProxyInjectionSync(client, maoManagedDeployment, framework.MachineAPINamespace, false)).To(BeTrue())
-
-		err = framework.DestroyClusterProxy(client)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -270,5 +267,8 @@ var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide prox
 		By("waiting for KCM cluster operator to become available")
 		Expect(framework.WaitForStatusAvailableOverLong(client, "kube-controller-manager")).To(BeTrue())
 		Expect(framework.WaitForStatusAvailableMedium(client, "machine-api")).To(BeTrue())
+
+		By("Removing the mitm-proxy")
+		Expect(framework.DestroyClusterProxy(client)).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -207,6 +207,13 @@ var _ = Describe("[Feature:Operators] Machine API cluster operator status should
 
 var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide proxy is configured, Machine API cluster operator should ", func() {
 	It("create machines when configured behind a proxy", func() {
+		// This test case takes upwards of 20 minutes to complete.
+		// This test cannot be run in parallel with other tests and as such,
+		// this test has a very high cost associated with it.
+		// The pass rate of this test is normally very good, so we can skip
+		// for now until we are able to move this into a periodic job.
+		Skip("This test is disruptive, slow and expensive. It should only be run periodically and not on presubmits. Skipping until we set up periodics")
+
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/providers/aws.go
+++ b/pkg/providers/aws.go
@@ -39,6 +39,8 @@ var _ = Describe("[Feature:Machines] [AWS] MetadataServiceOptions", func() {
 	AfterEach(func() {
 		Expect(framework.DeleteMachineSets(client, toDelete...)).To(Succeed())
 		toDelete = make([]*machinev1.MachineSet, 0, 3)
+
+		framework.WaitForMachineSetsDeleted(client, toDelete...)
 	})
 
 	createMachineSet := func(metadataAuth string) (*machinev1.MachineSet, error) {


### PR DESCRIPTION
This PR backports various improvements to the package back into `release-4.11`.