### PR TITLE
OCPCLOUD-1757: release-4.10, backport various improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ test-e2e: ## Run openshift specific e2e test
 	# After success, merge all JUnit files into one
 	hack/junitmerge.sh
 
+.PHONY: test-e2e-lifecyclehooks
+test-e2e-lifecyclehooks:
+	hack/ci-integration.sh $(GINKGO_ARGS) -focus="Lifecycle" || (hack/junitmerge.sh && exit 1)
+
 test-e2e-tech-preview:
 	hack/ci-integration.sh $(GINKGO_ARGS) -focus="TechPreview"
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
 	  -e "GO111MODULE=$(GO111MODULE)" \
 	  -e "GOFLAGS=$(GOFLAGS)" \
 	  -e "GOPROXY=$(GOPROXY)" \
-	  openshift/origin-release:golang-1.17
+	  registry.ci.openshift.org/openshift/release:golang-1.17
   IMAGE_BUILD_CMD = $(ENGINE) build
 endif
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -46,7 +46,7 @@ func clusterAutoscalerResource(maxNodesTotal int) *caov1.ClusterAutoscaler {
 	// and that has high least common multiple to avoid a case
 	// when a node is considered to be empty even if there are
 	// pods already scheduled and running on the node.
-	unneededTimeString := "23s"
+	unneededTimeString := "60s"
 	return &caov1.ClusterAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -293,8 +293,9 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			Expect(client.Create(ctx, asr)).Should(Succeed())
 			cleanupObjects[asr.GetName()] = asr
 
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s", expectedReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(expectedReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-scale-from-zero", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s", uniqueJobName, expectedReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(expectedReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -353,9 +354,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			}
 
 			jobReplicas := expectedReplicas * int32(2)
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
-				jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-cleanup-after-scale-down", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -506,9 +508,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			// to the maximum MachineSet size this will create enough demand to
 			// grow the cluster to maximum size.
 			jobReplicas := maxMachineSetReplicas
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
-				jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-scale-to-maxnodestotal", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -605,9 +608,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			// expand its size by 2 nodes. the cluster autoscaler should
 			// place 1 node in each of the 2 MachineSets created.
 			jobReplicas := int32(4)
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
-				jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-balance-nodegroups", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -514,9 +514,12 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			// At this point the autoscaler should be growing the cluster, we
 			// wait until the cluster has grown to reach MaxNodesTotal size.
+			// Because the autoscaler will ignore nodes that are not ready or unschedulable,
+			// we need to check against the number of ready nodes in the cluster since
+			// previous tests might have left nodes that are not ready or unschedulable.
 			By(fmt.Sprintf("Waiting for cluster to scale up to %d nodes", caMaxNodesTotal))
 			Eventually(func() (bool, error) {
-				nodes, err := framework.GetNodes(client)
+				nodes, err := framework.GetReadyAndSchedulableNodes(client)
 				return len(nodes) == caMaxNodesTotal, err
 			}, framework.WaitLong, pollingInterval).Should(BeTrue())
 
@@ -528,9 +531,12 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			// Now that the cluster has reached maximum size, we want to ensure
 			// that it doesn't try to grow larger.
+			// Because the autoscaler will ignore nodes that are not ready or unschedulable,
+			// we need to check against the number of ready nodes in the cluster since
+			// previous tests might have left nodes that are not ready or unschedulable.
 			By("Watching Cluster node count to ensure it remains consistent")
 			Consistently(func() (bool, error) {
-				nodes, err := framework.GetNodes(client)
+				nodes, err := framework.GetReadyAndSchedulableNodes(client)
 				return len(nodes) == caMaxNodesTotal, err
 			}, framework.WaitShort, pollingInterval).Should(BeTrue())
 

--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -64,11 +64,11 @@ var _ = BeforeSuite(func() {
 	client, err := framework.LoadClient()
 	Expect(err).ToNot(HaveOccurred())
 
-	infra, err := framework.GetInfrastructure(client)
+	platform, err := framework.GetPlatform(client)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Extend timeouts for slower providers
-	switch infra.Status.PlatformStatus.Type {
+	switch platform {
 	case osconfigv1.AzurePlatformType, osconfigv1.VSpherePlatformType, osconfigv1.OpenStackPlatformType:
 		framework.WaitShort = 2 * time.Minute  // Normally 1m
 		framework.WaitMedium = 6 * time.Minute // Normally 3m

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -29,12 +29,13 @@ const (
 	RetryMedium             = 5 * time.Second
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil
-	DefaultMachineSetReplicas = 0
-	MachinePhaseRunning       = "Running"
-	MachinePhaseFailed        = "Failed"
-	MachineRoleLabel          = "machine.openshift.io/cluster-api-machine-role"
-	MachineTypeLabel          = "machine.openshift.io/cluster-api-machine-type"
-	MachineAnnotationKey      = "machine.openshift.io/machine"
+	DefaultMachineSetReplicas  = 0
+	MachinePhaseRunning        = "Running"
+	MachinePhaseFailed         = "Failed"
+	MachineRoleLabel           = "machine.openshift.io/cluster-api-machine-role"
+	MachineTypeLabel           = "machine.openshift.io/cluster-api-machine-type"
+	MachineAnnotationKey       = "machine.openshift.io/machine"
+	ClusterAPIActuatorPkgTaint = "cluster-api-actuator-pkg"
 )
 
 var (

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -31,6 +31,7 @@ const (
 	// if MachineSet.Spec.Replicas field is set to nil
 	DefaultMachineSetReplicas = 0
 	MachinePhaseRunning       = "Running"
+	MachinePhaseFailed        = "Failed"
 	MachineRoleLabel          = "machine.openshift.io/cluster-api-machine-role"
 	MachineTypeLabel          = "machine.openshift.io/cluster-api-machine-type"
 	MachineAnnotationKey      = "machine.openshift.io/machine"

--- a/pkg/framework/jobs.go
+++ b/pkg/framework/jobs.go
@@ -1,0 +1,63 @@
+package framework
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func NewWorkLoad(njobs int32, memoryRequest resource.Quantity, workloadJobName string,
+	testLabel string, nodeSelector string, podLabel string) *batchv1.Job {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workloadJobName,
+			Namespace: "default",
+			Labels:    map[string]string{testLabel: ""},
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  workloadJobName,
+							Image: "busybox",
+							Command: []string{
+								"sleep",
+								"86400", // 1 day
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"memory": memoryRequest,
+									"cpu":    resource.MustParse("500m"),
+								},
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicy("Never"),
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "kubemark",
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+			},
+			BackoffLimit: pointer.Int32Ptr(4),
+			Completions:  pointer.Int32Ptr(njobs),
+			Parallelism:  pointer.Int32Ptr(njobs),
+		},
+	}
+	if nodeSelector != "" {
+		job.Spec.Template.Spec.NodeSelector = map[string]string{
+			nodeSelector: "",
+		}
+	}
+	if podLabel != "" {
+		job.Spec.Template.ObjectMeta.Labels = map[string]string{
+			podLabel: "",
+		}
+	}
+	return job
+}

--- a/pkg/framework/jobs.go
+++ b/pkg/framework/jobs.go
@@ -41,6 +41,10 @@ func NewWorkLoad(njobs int32, memoryRequest resource.Quantity, workloadJobName s
 							Key:      "kubemark",
 							Operator: corev1.TolerationOpExists,
 						},
+						{
+							Key:    ClusterAPIActuatorPkgTaint,
+							Effect: corev1.TaintEffectPreferNoSchedule,
+						},
 					},
 				},
 			},

--- a/pkg/framework/jobs.go
+++ b/pkg/framework/jobs.go
@@ -13,7 +13,7 @@ func NewWorkLoad(njobs int32, memoryRequest resource.Quantity, workloadJobName s
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workloadJobName,
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 			Labels:    map[string]string{testLabel: ""},
 		},
 		Spec: batchv1.JobSpec{

--- a/pkg/framework/machines.go
+++ b/pkg/framework/machines.go
@@ -19,18 +19,24 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// FilterRunningMachines returns a slice of only those Machines in the input
-// that are in the "Running" phase.
-func FilterRunningMachines(machines []*machinev1.Machine) []*machinev1.Machine {
+// FilterMachines returns a slice of only those Machines in the input that are
+// in the requested phase.
+func FilterMachines(machines []*machinev1.Machine, phase string) []*machinev1.Machine {
 	var result []*machinev1.Machine
 
 	for i, m := range machines {
-		if m.Status.Phase != nil && *m.Status.Phase == MachinePhaseRunning {
+		if m.Status.Phase != nil && *m.Status.Phase == phase {
 			result = append(result, machines[i])
 		}
 	}
 
 	return result
+}
+
+// FilterRunningMachines returns a slice of only those Machines in the input
+// that are in the "Running" phase.
+func FilterRunningMachines(machines []*machinev1.Machine) []*machinev1.Machine {
+	return FilterMachines(machines, MachinePhaseRunning)
 }
 
 // GetMachine get a machine by its name from the default machine API namespace.

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	machinev1 "github.com/openshift/api/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,6 +29,7 @@ type MachineSetParams struct {
 	Name         string
 	Replicas     int32
 	Labels       map[string]string
+	Taints       []corev1.Taint
 	ProviderSpec *machinev1.ProviderSpec
 }
 
@@ -59,6 +61,12 @@ func BuildMachineSetParams(client runtimeclient.Client, replicas int) MachineSet
 			"e2e.openshift.io": uid.String(),
 			ClusterKey:         clusterName,
 		},
+		Taints: []corev1.Taint{
+			corev1.Taint{
+				Key:    ClusterAPIActuatorPkgTaint,
+				Effect: corev1.TaintEffectPreferNoSchedule,
+			},
+		},
 	}
 }
 
@@ -87,6 +95,7 @@ func CreateMachineSet(c client.Client, params MachineSetParams) (*machinev1.Mach
 						Labels: params.Labels,
 					},
 					ProviderSpec: *params.ProviderSpec,
+					Taints:       params.Taints,
 				},
 			},
 			Replicas: pointer.Int32Ptr(params.Replicas),

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -398,15 +398,16 @@ func WaitForMachineSetsDeleted(c runtimeclient.Client, machineSets ...*machinev1
 				return fmt.Errorf("%d Machines still present for MachineSet %s", len(machines), ms.GetName())
 			}
 
-			if err := c.Get(context.Background(), runtimeclient.ObjectKey{
+			machineSetErr := c.Get(context.Background(), runtimeclient.ObjectKey{
 				Name:      ms.GetName(),
 				Namespace: ms.GetNamespace(),
-			}, &machinev1.MachineSet{}); err != nil && !apierrors.IsNotFound(err) {
+			}, &machinev1.MachineSet{})
+			if machineSetErr != nil && !apierrors.IsNotFound(machineSetErr) {
 				return fmt.Errorf("could not fetch MachineSet %s: %v", ms.GetName(), err)
 			}
 
 			// No error means the MachineSet still exists.
-			if err == nil {
+			if machineSetErr == nil {
 				return fmt.Errorf("MachineSet %s still present, but has no Machines", ms.GetName())
 			}
 

--- a/pkg/framework/pods.go
+++ b/pkg/framework/pods.go
@@ -1,9 +1,13 @@
 package framework
 
 import (
+	"bytes"
 	"context"
+	"io"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -12,4 +16,55 @@ func GetPods(client runtimeclient.Client, selector map[string]string) (*corev1.P
 	pods := &corev1.PodList{}
 	err := client.List(context.TODO(), pods, runtimeclient.MatchingLabels(selector))
 	return pods, err
+}
+
+type PodCleanupFunc func() error
+
+type PodLastLogFunc func(container string, lines int, previous bool) (string, error)
+
+// RunPodOnNode runs a pod according passed spec on particular node.
+// returns created pod object, function for retrieve last logs, cleanup function and error if occurred
+func RunPodOnNode(clientset *kubernetes.Clientset, node *corev1.Node, namespace string, podSpec corev1.PodSpec) (*corev1.Pod, PodLastLogFunc, PodCleanupFunc, error) {
+	var err error
+	podSpec.NodeName = node.Name
+	pod := &corev1.Pod{
+		Spec: podSpec,
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "machine-api-e2e-",
+		},
+	}
+
+	pod, err = clientset.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	cleanup := func() error {
+		return clientset.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+	}
+
+	lastLog := func(container string, lines int, previous bool) (string, error) {
+		tailLines := int64(lines)
+		req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+			Container: container,
+			Follow:    true,
+			Previous:  previous,
+			TailLines: &tailLines,
+		})
+		podLogs, err := req.Stream(context.TODO())
+		if err != nil {
+			return "", err
+		}
+		defer podLogs.Close()
+		buf := new(bytes.Buffer)
+		_, err = io.Copy(buf, podLogs)
+		if err != nil {
+			return "", err
+		}
+		logs := buf.String()
+
+		return logs, nil
+	}
+
+	return pod, lastLog, cleanup, err
 }

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -15,12 +15,11 @@ import (
 )
 
 const proxySetup = `
-cd /root
-mkdir /root/.mitmproxy
-cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem
+cd /.mitmproxy
+cat /root/certs/tls.key /root/certs/tls.crt > /.mitmproxy/mitmproxy-ca.pem
 curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
 tar xvf mitmproxy-5.3.0-linux.tar.gz
-./mitmdump
+HOME=/.mitmproxy ./mitmdump
 `
 
 const mitmSignerCert = `
@@ -144,6 +143,12 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 								},
 							},
 						},
+						{
+							Name: "mitm-workdir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -166,6 +171,11 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 									Name:      "mitm-signer",
 									ReadOnly:  false,
 									MountPath: "/root/certs",
+								},
+								{
+									Name:      "mitm-workdir",
+									ReadOnly:  false,
+									MountPath: "/.mitmproxy",
 								},
 							},
 						},

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -16,10 +16,10 @@ import (
 const proxySetup = `
 cd /root
 mkdir /root/.mitmproxy
-cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem  
+cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem
 curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
 tar xvf mitmproxy-5.3.0-linux.tar.gz
-./mitmdump 
+./mitmdump
 `
 
 const mitmSignerCert = `
@@ -65,14 +65,14 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      "mitm-proxy",
-		Namespace: "default",
+		Namespace: MachineAPINamespace,
 		Labels:    mitmDeploymentLabels,
 	}
 
 	mitmSigner := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-signer",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 			Labels:    mitmDeploymentLabels,
 		},
 		Data: map[string][]byte{
@@ -87,7 +87,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	mitmBootstrapConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-bootstrap",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 		Data: map[string]string{
 			"startup.sh": proxySetup,
@@ -178,7 +178,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 		return err
 	}
 
-	IsDaemonsetAvailable(c, "mitm-proxy", "default")
+	IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace)
 
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
@@ -199,7 +199,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	if err != nil {
 		return err
 	}
-	IsServiceAvailable(c, "mitm-proxy", "default")
+	IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace)
 
 	return err
 }
@@ -212,14 +212,14 @@ func DestroyClusterProxy(c runtimeclient.Client) error {
 
 	mitmObjectMeta := metav1.ObjectMeta{
 		Name:      "mitm-proxy",
-		Namespace: "default",
+		Namespace: MachineAPINamespace,
 		Labels:    mitmDeploymentLabels,
 	}
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-bootstrap",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 	}
 	err := c.Delete(context.Background(), configMap)
@@ -241,7 +241,7 @@ func DestroyClusterProxy(c runtimeclient.Client) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-signer",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 	}
 	err = c.Delete(context.Background(), secret)

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -178,7 +179,9 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 		return err
 	}
 
-	IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace)
+	if !IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace) {
+		return errors.New("daemonset did not become available")
+	}
 
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
@@ -199,7 +202,9 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	if err != nil {
 		return err
 	}
-	IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace)
+	if !IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace) {
+		return errors.New("service did not become available")
+	}
 
 	return err
 }

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -289,13 +289,18 @@ var _ = Describe("[Feature:Machines] Managed cluster should", func() {
 		}()
 
 		By("Creating RC with workload")
-		rc := replicationControllerWorkload("default")
+
+		// Use the openshift-machine-api namespace as it is excluded from
+		// Pod security admission checks.
+		namespace := framework.MachineAPINamespace
+
+		rc := replicationControllerWorkload(namespace)
 		err = client.Create(context.TODO(), rc)
 		Expect(err).NotTo(HaveOccurred())
 		delObjects["rc"] = rc
 
 		By("Creating PDB for RC")
-		pdb := podDisruptionBudget("default")
+		pdb := podDisruptionBudget(namespace)
 		err = client.Create(context.TODO(), pdb)
 		Expect(err).NotTo(HaveOccurred())
 		delObjects["pdb"] = pdb

--- a/pkg/infra/lifecyclehooks.go
+++ b/pkg/infra/lifecyclehooks.go
@@ -1,0 +1,189 @@
+package infra
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	lifecycleHooksTestLabel           = "test.lifecyclehooks.label"
+	lifecycleHooksPodLabel            = "e2e.lifecyclehooks.pod.label"
+	lifecyclehooksWorkerNodeRoleLabel = "machine.openshift.io/lifecyclehooks-e2e-worker"
+	lifecycleWorkloadJobName          = "e2e-lifecyclehooks-workload"
+	pollingInterval                   = 3 * time.Second
+)
+
+var _ = Describe("[Feature:Machine] Lifecycle Hooks should", func() {
+	var client runtimeclient.Client
+	var machineSet *machinev1.MachineSet
+	var workload *batchv1.Job
+	var pod corev1.Pod
+
+	BeforeEach(func() {
+		var err error
+
+		By("Creating the machineset")
+		client, err = framework.LoadClient()
+		// Build machine set parameters
+		expectedReplicas := 1
+		machineSetParams := framework.BuildMachineSetParams(client, expectedReplicas)
+		// Create a label for node and add to machine set parameters
+		machineSetParams.Labels[lifecyclehooksWorkerNodeRoleLabel] = ""
+		// Create machine set
+		machineSet, err = framework.CreateMachineSet(client, machineSetParams)
+		Expect(err).ToNot(HaveOccurred())
+		// Wait for machine to be running
+		framework.WaitForMachineSet(client, machineSet.GetName())
+
+		By("Running a workload on the machine")
+		// Run a pod on this machine
+		workloadMemRequest := resource.MustParse("100m")
+		workload = framework.NewWorkLoad(int32(expectedReplicas), workloadMemRequest,
+			lifecycleWorkloadJobName, lifecycleHooksTestLabel, lifecyclehooksWorkerNodeRoleLabel, lifecycleHooksPodLabel)
+		Expect(client.Create(context.Background(), workload)).To(Succeed(), "Could not create workload job")
+
+		By("Waiting for job pod to start running on machine.")
+		Eventually(func() (bool, error) {
+			jobPodList, err := framework.GetPods(client, map[string]string{lifecycleHooksPodLabel: ""})
+			if err != nil {
+				return false, err
+			}
+			if len(jobPodList.Items) == expectedReplicas {
+				pod = jobPodList.Items[0]
+				return pod.Status.Phase == corev1.PodRunning, nil
+			}
+			return false, nil
+		}, framework.WaitLong, pollingInterval).Should(BeTrue(), "Pod did not start running on machine")
+	})
+
+	AfterEach(func() {
+		By("Deleting the machineset")
+		cascadeDelete := metav1.DeletePropagationForeground
+		Expect(client.Delete(context.Background(), machineSet, &runtimeclient.DeleteOptions{
+			PropagationPolicy: &cascadeDelete,
+		})).To(Succeed())
+		By("Deleting workload job")
+		Expect(client.Delete(context.Background(), workload, &runtimeclient.DeleteOptions{
+			PropagationPolicy: &cascadeDelete,
+		})).To(Succeed())
+	})
+
+	It("pause lifecycle actions when present", func() {
+		machines, err := framework.GetMachinesFromMachineSet(client, machineSet)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(machines).To(HaveLen(1), "There should be only one machine")
+		machine := machines[0]
+		podKey := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+		machineKey := types.NamespacedName{Namespace: machine.Namespace, Name: machine.Name}
+
+		By("Setting lifecycle hooks on the machine")
+		predrainHook := machinev1.LifecycleHook{
+			Name:  "cluster-api-actuator-pkg/pre-drainHook",
+			Owner: "cluster-api-actuator-pkg",
+		}
+		preterminateHook := machinev1.LifecycleHook{
+			Name:  "cluster-api-actuator-pkg/pre-terminateHook",
+			Owner: "cluster-api-actuator-pkg",
+		}
+		Eventually(func() (bool, error) {
+			if err = client.Get(context.Background(), machineKey, machine); err != nil {
+				return false, err
+			}
+			machine.Spec.LifecycleHooks.PreDrain = []machinev1.LifecycleHook{predrainHook}
+			machine.Spec.LifecycleHooks.PreTerminate = []machinev1.LifecycleHook{preterminateHook}
+			if err := client.Update(context.Background(), machine); err != nil {
+				return false, err
+			}
+			return true, nil
+		}, framework.WaitShort, pollingInterval).Should(BeTrue(),
+			"Could not add lifecycle hooks to machine")
+
+		By("Deleting the machine")
+		// Delete the machine by scaling down the machineset to zero
+		framework.ScaleMachineSet(machineSet.Name, 0)
+
+		By("Checking that workload pod is running on machine")
+		// pre-drain hook should prevent pod from being evicted
+		Eventually(func() (bool, error) {
+			if err := client.Get(context.Background(), podKey, &pod); err != nil {
+				return false, err
+			}
+			if err := client.Get(context.Background(), machineKey, machine); err != nil {
+				return false, err
+			}
+			// Check that machine drainable false condition is set
+			for _, condition := range machine.Status.Conditions {
+				if condition.Type == machinev1.MachineDrainable && condition.Status == corev1.ConditionFalse {
+					return pod.Status.Phase == corev1.PodRunning, nil
+				}
+			}
+			return false, nil
+		}, framework.WaitMedium, pollingInterval).Should(BeTrue(),
+			"Workload pod was evicted from the machine or drainable condition is not set")
+
+		By("Removing pre-drain hook")
+		Eventually(func() (bool, error) {
+			if err := client.Get(context.Background(), machineKey, machine); err != nil {
+				return false, err
+			}
+			machine.Spec.LifecycleHooks.PreDrain = []machinev1.LifecycleHook{}
+			if err := client.Update(context.Background(), machine); err != nil {
+				return false, err
+			}
+			return true, nil
+		}, framework.WaitShort, pollingInterval).Should(BeTrue(), "Could not delete pre-drain hook")
+
+		By("Checking that workload pod is evicted from the machine")
+		// Check that pod is evicted, but machine is still present
+		Eventually(func() bool {
+			err = client.Get(context.Background(), podKey, &pod)
+			return apierrors.IsNotFound(err)
+		}, framework.WaitMedium, pollingInterval).Should(BeTrue(), "Pod was not evicted from machine")
+		Eventually(func() (bool, error) {
+			if err := client.Get(context.Background(), machineKey, machine); err != nil {
+				return false, err
+			}
+			// Machine phase should be "Deleting"
+			// but pre-terminate hook should prevent deletion and set terminable false condition
+			for _, condition := range machine.Status.Conditions {
+				if condition.Type == machinev1.MachineTerminable && condition.Status == corev1.ConditionFalse {
+					return *machine.Status.Phase == "Deleting", nil
+				}
+			}
+			return false, nil
+		}, framework.WaitMedium, pollingInterval).Should(BeTrue(),
+			"Machine was deleted or terminable condition is not set")
+
+		By("Removing pre-terminate hook")
+		Eventually(func() (bool, error) {
+			if err := client.Get(context.Background(), machineKey, machine); err != nil {
+				return false, err
+			}
+			machine.Spec.LifecycleHooks.PreTerminate = []machinev1.LifecycleHook{}
+			if err = client.Update(context.Background(), machine); err != nil {
+				return false, err
+			}
+			return true, nil
+		}, framework.WaitShort, pollingInterval).Should(BeTrue(),
+			"Could not delete pre-termiante hook")
+
+		By("Checking that machine is deleted")
+		Eventually(func() bool {
+			err = client.Get(context.Background(), machineKey, machine)
+			return apierrors.IsNotFound(err)
+		}, framework.WaitLong, pollingInterval).Should(BeTrue(), "Machine was not deleted")
+	})
+})

--- a/pkg/infra/lifecyclehooks.go
+++ b/pkg/infra/lifecyclehooks.go
@@ -75,6 +75,10 @@ var _ = Describe("[Feature:Machine] Lifecycle Hooks should", func() {
 		Expect(client.Delete(context.Background(), machineSet, &runtimeclient.DeleteOptions{
 			PropagationPolicy: &cascadeDelete,
 		})).To(Succeed())
+
+		By("Waiting for the MachineSet to be deleted...")
+		framework.WaitForMachineSetDelete(client, machineSet)
+
 		By("Deleting workload job")
 		Expect(client.Delete(context.Background(), workload, &runtimeclient.DeleteOptions{
 			PropagationPolicy: &cascadeDelete,

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -43,12 +43,16 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 		var err error
 		client, err = framework.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
-		// Only run on AWS
+
 		platform, err = framework.GetPlatform(client)
 		Expect(err).NotTo(HaveOccurred())
 		switch platform {
 		case configv1.AWSPlatformType, configv1.AzurePlatformType:
-			// Do Nothing
+			// The failure rate of this test has increased significantly on Azure and AWS.
+			// We are seeing a massive spike in not being able to create instances due to
+			// a lack of capacity on the platform.
+			// Skip the test until we have time to work out how to mitigate this.
+			Skip("This test has a high failure rate, skipping until further notice")
 		case configv1.GCPPlatformType:
 			// TODO: GCP relies on the metadata IP for DNS.
 			// This test prevents it from accessing the DNS, therefore

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -25,6 +25,8 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const machinesCount = 3
+
 var _ = Describe("[Feature:Machines] Running on Spot", func() {
 	var ctx = context.Background()
 
@@ -42,9 +44,8 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 		client, err = framework.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
 		// Only run on AWS
-		clusterInfra, err := framework.GetInfrastructure(client)
+		platform, err = framework.GetPlatform(client)
 		Expect(err).NotTo(HaveOccurred())
-		platform = clusterInfra.Status.PlatformStatus.Type
 		switch platform {
 		case configv1.AWSPlatformType, configv1.AzurePlatformType:
 			// Do Nothing
@@ -60,7 +61,7 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 		}
 
 		By("Creating a Spot backed MachineSet", func() {
-			machineSetParams = framework.BuildMachineSetParams(client, 3)
+			machineSetParams = framework.BuildMachineSetParams(client, machinesCount)
 			Expect(setSpotOnProviderSpec(platform, machineSetParams, "")).To(Succeed())
 
 			machineSet, err = framework.CreateMachineSet(client, machineSetParams)
@@ -80,7 +81,7 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 			selector := machineSet.Spec.Selector
 			machines, err := framework.GetMachines(client, &selector)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(machines).To(HaveLen(3))
+			Expect(machines).To(HaveLen(machinesCount))
 
 			for _, machine := range machines {
 				Expect(machine.Spec.ObjectMeta.Labels).To(HaveKeyWithValue(machinecontroller.MachineInterruptibleInstanceLabelName, ""))
@@ -90,7 +91,7 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 		By("should deploy a termination handler pod to each instance", func() {
 			nodes, err := framework.GetNodesFromMachineSet(client, machineSet)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(nodes).To(HaveLen(3))
+			Expect(nodes).To(HaveLen(machinesCount))
 
 			terminationLabels := map[string]string{
 				"api":     "clusterapi",

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -73,7 +73,24 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 	})
 
 	AfterEach(func() {
-		Expect(deleteObjects(client, delObjects)).To(Succeed())
+		var machineSets []*machinev1.MachineSet
+
+		for _, obj := range delObjects {
+			if machineSet, ok := obj.(*machinev1.MachineSet); ok {
+				// Once we delete a MachineSet we should make sure that the
+				// all of its machines are deleted as well.
+				// Collect MachineSets to wait for.
+				machineSets = append(machineSets, machineSet)
+			}
+
+			Expect(deleteObject(client, obj)).To(Succeed())
+		}
+
+		if len(machineSets) > 0 {
+			// Wait for all MachineSets and their Machines to be deleted.
+			By("Waiting for MachineSets to be deleted...")
+			framework.WaitForMachineSetsDeleted(client, machineSets...)
+		}
 	})
 
 	It("should handle the spot instances", func() {

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -49,6 +49,16 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 		testSelector = &metav1.LabelSelector{
 			MatchLabels: machineSetParams.Labels,
 		}
+
+		By("Checking the webhook configurations are synced", func() {
+			Eventually(func() bool {
+				return framework.IsMutatingWebhookConfigurationSynced(client)
+			}, framework.WaitShort).Should(BeTrue(), "MutatingWebhookConfiguration must be synced before running these tests")
+
+			Eventually(func() bool {
+				return framework.IsValidatingWebhookConfigurationSynced(client)
+			}, framework.WaitShort).Should(BeTrue(), "ValidingWebhookConfiguration must be synced before running these tests")
+		})
 	})
 
 	AfterEach(func() {

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -188,6 +188,7 @@ func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec
 				Placement:          fullProviderSpec.Placement,
 				Subnet:             *fullProviderSpec.Subnet.DeepCopy(),
 				IAMInstanceProfile: fullProviderSpec.IAMInstanceProfile.DeepCopy(),
+				SecurityGroups:     fullProviderSpec.SecurityGroups,
 			},
 		},
 	}, nil

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
-	machinev1 "github.com/openshift/api/machine/v1beta1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,13 +64,13 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 
 	It("should be able to create a machine from a minimal providerSpec", func() {
-		machine := &machinev1.Machine{
+		machine := &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-webhook-", machineSetParams.Name),
 				Namespace:    framework.MachineAPINamespace,
 				Labels:       machineSetParams.Labels,
 			},
-			Spec: machinev1.MachineSpec{
+			Spec: machinev1beta1.MachineSpec{
 				ProviderSpec: *machineSetParams.ProviderSpec,
 			},
 		}
@@ -81,7 +81,7 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 			if err != nil {
 				return err
 			}
-			running := framework.FilterRunningMachines([]*machinev1.Machine{m})
+			running := framework.FilterRunningMachines([]*machinev1beta1.Machine{m})
 			if len(running) == 0 {
 				return fmt.Errorf("machine not yet running")
 			}
@@ -97,13 +97,13 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 
 	It("should return an error when removing required fields from the Machine providerSpec", func() {
-		machine := &machinev1.Machine{
+		machine := &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-webhook-", machineSetParams.Name),
 				Namespace:    framework.MachineAPINamespace,
 				Labels:       machineSetParams.Labels,
 			},
-			Spec: machinev1.MachineSpec{
+			Spec: machinev1beta1.MachineSpec{
 				ProviderSpec: *machineSetParams.ProviderSpec,
 			},
 		}
@@ -159,7 +159,7 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 })
 
-func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
+func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
 	switch platform {
 	case configv1.AWSPlatformType:
 		return minimalAWSProviderSpec(ps)
@@ -175,15 +175,15 @@ func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1.Pro
 	}
 }
 
-func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
-	fullProviderSpec := &machinev1.AWSMachineProviderConfig{}
+func minimalAWSProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
+	fullProviderSpec := &machinev1beta1.AWSMachineProviderConfig{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
-			Object: &machinev1.AWSMachineProviderConfig{
+			Object: &machinev1beta1.AWSMachineProviderConfig{
 				AMI:                fullProviderSpec.AMI,
 				Placement:          fullProviderSpec.Placement,
 				Subnet:             *fullProviderSpec.Subnet.DeepCopy(),
@@ -194,17 +194,17 @@ func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec
 	}, nil
 }
 
-func minimalAzureProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
-	fullProviderSpec := &machinev1.AzureMachineProviderSpec{}
+func minimalAzureProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
+	fullProviderSpec := &machinev1beta1.AzureMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
-			Object: &machinev1.AzureMachineProviderSpec{
+			Object: &machinev1beta1.AzureMachineProviderSpec{
 				Location: fullProviderSpec.Location,
-				OSDisk: machinev1.OSDisk{
+				OSDisk: machinev1beta1.OSDisk{
 					DiskSizeGB: fullProviderSpec.OSDisk.DiskSizeGB,
 				},
 			},
@@ -212,15 +212,15 @@ func minimalAzureProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSp
 	}, nil
 }
 
-func minimalGCPProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
-	fullProviderSpec := &machinev1.GCPMachineProviderSpec{}
+func minimalGCPProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
+	fullProviderSpec := &machinev1beta1.GCPMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
-			Object: &machinev1.GCPMachineProviderSpec{
+			Object: &machinev1beta1.GCPMachineProviderSpec{
 				Region:          fullProviderSpec.Region,
 				Zone:            fullProviderSpec.Zone,
 				ServiceAccounts: fullProviderSpec.ServiceAccounts,
@@ -229,8 +229,8 @@ func minimalGCPProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec
 	}, nil
 }
 
-func minimalVSphereProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
-	providerSpec := &machinev1.VSphereMachineProviderSpec{}
+func minimalVSphereProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
+	providerSpec := &machinev1beta1.VSphereMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, providerSpec)
 	if err != nil {
 		return nil, err
@@ -238,7 +238,7 @@ func minimalVSphereProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.Provider
 	// For vSphere only these 2 fields are defaultable
 	providerSpec.UserDataSecret = nil
 	providerSpec.CredentialsSecret = nil
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: providerSpec,
 		},

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -253,9 +253,6 @@ var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide prox
 
 		By("waiting for machine-api-controller deployment to reflect unconfigured cluster-wide proxy")
 		Expect(framework.WaitForProxyInjectionSync(client, maoManagedDeployment, framework.MachineAPINamespace, false)).To(BeTrue())
-
-		err = framework.DestroyClusterProxy(client)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -270,5 +267,8 @@ var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide prox
 		By("waiting for KCM cluster operator to become available")
 		Expect(framework.WaitForStatusAvailableOverLong(client, "kube-controller-manager")).To(BeTrue())
 		Expect(framework.WaitForStatusAvailableMedium(client, "machine-api")).To(BeTrue())
+
+		By("Removing the mitm-proxy")
+		Expect(framework.DestroyClusterProxy(client)).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -207,6 +207,13 @@ var _ = Describe("[Feature:Operators] Machine API cluster operator status should
 
 var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide proxy is configured, Machine API cluster operator should ", func() {
 	It("create machines when configured behind a proxy", func() {
+		// This test case takes upwards of 20 minutes to complete.
+		// This test cannot be run in parallel with other tests and as such,
+		// this test has a very high cost associated with it.
+		// The pass rate of this test is normally very good, so we can skip
+		// for now until we are able to move this into a periodic job.
+		Skip("This test is disruptive, slow and expensive. It should only be run periodically and not on presubmits. Skipping until we set up periodics")
+
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
This PR backports various improvements to the package back into `release-4.10`.

3 notable changes that differ from a plain cherry-pick of all commits:

1) [backport: pkg/infra cleanup](https://github.com/openshift/cluster-api-actuator-pkg/commit/127c62689438075f34c917ac5054a0bbcb35be1e) is a squashed and fixed up version of:
    ```
    backport: pkg/infra cleanup
    A fixup of 4 commits plus
    removal of unndeded aws IMDSv2 tests (feature not present on 4.10) from backport
    
    | * https://github.com/openshift/cluster-api-actuator-pkg/commit/38d03aac8b59e9d75b967eae0a5bf1c0f4ef7aa6 update error construction in GetPlatform func (6 months ago) <Denis Moiseev>
    | * https://github.com/openshift/cluster-api-actuator-pkg/commit/82e156081765425ce523749f373d577bcba3edf0 Fix broken spot tests, rename helper, small cleanup (6 months ago) <Denis Moiseev>
    | * https://github.com/openshift/cluster-api-actuator-pkg/commit/6547ca3ffc00dfbbf486ff30708635bde07e1f31 AWS IMDSv2 feature tests (6 months ago) <Denis Moiseev>
    | * https://github.com/openshift/cluster-api-actuator-pkg/commit/f5644f407bc8638f2a4a4b94e01f85be9332cda9 Upd openshift/api, revendor (6 months ago) <Denis Moiseev>
    ```
2) [[4.10 backport] Wait for Machines to be deleted before completeing ea…](https://github.com/openshift/cluster-api-actuator-pkg/commit/74303bbec0ec46437fc995f6995fb11ca7fc959b)
is a fixup version of the original commit where the changes for `pkg/providers/aws.go` are not present because the file is not present on this branch.

3) [[4.10 backport] update Makefile container image](https://github.com/openshift/cluster-api-actuator-pkg/commit/52f27f7478c9196f47c3e309a1cd4f20f37931ca)
is a fixup version of the original commit where the changes to the container image repository are included but the version is set to `1.17` rather than `1.18`.