### PR TITLE
OCPCLOUD-1757: release-4.9, backport various improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ else
 	  -e "GO111MODULE=$(GO111MODULE)" \
 	  -e "GOFLAGS=$(GOFLAGS)" \
 	  -e "GOPROXY=$(GOPROXY)" \
-	  openshift/origin-release:golang-1.15
-  IMAGE_BUILD_CMD = docker build
+	  registry.ci.openshift.org/openshift/release:golang-1.15
+  IMAGE_BUILD_CMD = $(ENGINE) build
 endif
 
 .PHONY: all

--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,7 @@ approvers:
   - vikaschoudhary16
   - michaelgugino
   - alexander-demichev
-  - Danil-Grigorev
   - JoelSpeed
   - elmiko
+  - lobziik
+  - Fedosin

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
 	caov1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
 	caov1beta1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1"
-	mapiv1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -128,7 +128,7 @@ func clusterAutoscalerResource(maxNodesTotal int) *caov1.ClusterAutoscaler {
 }
 
 // Build MA resource from targeted machineset
-func machineAutoscalerResource(targetMachineSet *mapiv1beta1.MachineSet, minReplicas, maxReplicas int32) *caov1beta1.MachineAutoscaler {
+func machineAutoscalerResource(targetMachineSet *machinev1.MachineSet, minReplicas, maxReplicas int32) *caov1beta1.MachineAutoscaler {
 	return &caov1beta1.MachineAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("autoscale-%s", targetMachineSet.Name),
@@ -366,7 +366,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 		It("cleanup deletion information after scale down [Slow]", func() {
 			By("Creating 2 MachineSets each with 1 replica")
-			var transientMachineSets [2]*mapiv1beta1.MachineSet
+			var transientMachineSets [2]*machinev1.MachineSet
 			targetedNodeLabel := fmt.Sprintf("%v-delete-cleanup", autoscalerWorkerNodeRoleLabel)
 			for i, machineSet := range transientMachineSets {
 				machineSetParams := framework.BuildMachineSetParams(client, 1)
@@ -516,7 +516,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 		It("scales up and down while respecting MaxNodesTotal [Slow][Serial]", func() {
 			By("Creating 1 MachineSet with 1 replica")
-			var transientMachineSet *mapiv1beta1.MachineSet
+			var transientMachineSet *machinev1.MachineSet
 			targetedNodeLabel := fmt.Sprintf("%v-scale-updown", autoscalerWorkerNodeRoleLabel)
 			machineSetParams := framework.BuildMachineSetParams(client, 1)
 			machineSetParams.Labels[targetedNodeLabel] = ""
@@ -600,7 +600,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 		It("places nodes evenly across node groups [Slow]", func() {
 			By("Creating 2 MachineSets each with 1 replica")
-			var transientMachineSets [2]*mapiv1beta1.MachineSet
+			var transientMachineSets [2]*machinev1.MachineSet
 			targetedNodeLabel := fmt.Sprintf("%v-balance-nodes", autoscalerWorkerNodeRoleLabel)
 			for i, machineSet := range transientMachineSets {
 				machineSetParams := framework.BuildMachineSetParams(client, 1)

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -307,7 +307,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			platform := clusterInfra.Status.PlatformStatus.Type
 			switch platform {
-			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType:
+			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType:
 				klog.Infof("Platform is %v", platform)
 			default:
 				Skip(fmt.Sprintf("Platform %v does not support autoscaling from/to zero, skipping.", platform))

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -307,7 +307,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			platform := clusterInfra.Status.PlatformStatus.Type
 			switch platform {
-			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType:
+			case configv1.AWSPlatformType, configv1.GCPPlatformType, configv1.AzurePlatformType, configv1.OpenStackPlatformType, configv1.VSpherePlatformType:
 				klog.Infof("Platform is %v", platform)
 			default:
 				Skip(fmt.Sprintf("Platform %v does not support autoscaling from/to zero, skipping.", platform))

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -46,7 +46,7 @@ func clusterAutoscalerResource(maxNodesTotal int) *caov1.ClusterAutoscaler {
 	// and that has high least common multiple to avoid a case
 	// when a node is considered to be empty even if there are
 	// pods already scheduled and running on the node.
-	unneededTimeString := "23s"
+	unneededTimeString := "60s"
 	return &caov1.ClusterAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -293,8 +293,9 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			Expect(client.Create(ctx, asr)).Should(Succeed())
 			cleanupObjects[asr.GetName()] = asr
 
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s", expectedReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(expectedReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-scale-from-zero", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s", uniqueJobName, expectedReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(expectedReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -353,9 +354,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			}
 
 			jobReplicas := expectedReplicas * int32(2)
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
-				jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-cleanup-after-scale-down", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -506,9 +508,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			// to the maximum MachineSet size this will create enough demand to
 			// grow the cluster to maximum size.
 			jobReplicas := maxMachineSetReplicas
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
-				jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-scale-to-maxnodestotal", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -605,9 +608,10 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			// expand its size by 2 nodes. the cluster autoscaler should
 			// place 1 node in each of the 2 MachineSets created.
 			jobReplicas := int32(4)
-			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
-				jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			uniqueJobName := fmt.Sprintf("%s-balance-nodegroups", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -514,9 +514,12 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			// At this point the autoscaler should be growing the cluster, we
 			// wait until the cluster has grown to reach MaxNodesTotal size.
+			// Because the autoscaler will ignore nodes that are not ready or unschedulable,
+			// we need to check against the number of ready nodes in the cluster since
+			// previous tests might have left nodes that are not ready or unschedulable.
 			By(fmt.Sprintf("Waiting for cluster to scale up to %d nodes", caMaxNodesTotal))
 			Eventually(func() (bool, error) {
-				nodes, err := framework.GetNodes(client)
+				nodes, err := framework.GetReadyAndSchedulableNodes(client)
 				return len(nodes) == caMaxNodesTotal, err
 			}, framework.WaitLong, pollingInterval).Should(BeTrue())
 
@@ -528,9 +531,12 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 
 			// Now that the cluster has reached maximum size, we want to ensure
 			// that it doesn't try to grow larger.
+			// Because the autoscaler will ignore nodes that are not ready or unschedulable,
+			// we need to check against the number of ready nodes in the cluster since
+			// previous tests might have left nodes that are not ready or unschedulable.
 			By("Watching Cluster node count to ensure it remains consistent")
 			Consistently(func() (bool, error) {
-				nodes, err := framework.GetNodes(client)
+				nodes, err := framework.GetReadyAndSchedulableNodes(client)
 				return len(nodes) == caMaxNodesTotal, err
 			}, framework.WaitShort, pollingInterval).Should(BeTrue())
 

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -14,7 +14,6 @@ import (
 	caov1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1"
 	caov1beta1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -38,58 +37,6 @@ const (
 	deletionCandidateTaintKey             = "DeletionCandidateOfClusterAutoscaler"
 	toBeDeletedTaintKey                   = "ToBeDeletedByClusterAutoscaler"
 )
-
-func newWorkLoad(njobs int32, memoryRequest resource.Quantity, nodeSelector string) *batchv1.Job {
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      workloadJobName,
-			Namespace: "default",
-			Labels:    map[string]string{autoscalingTestLabel: ""},
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Job",
-			APIVersion: "batch/v1",
-		},
-		Spec: batchv1.JobSpec{
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  workloadJobName,
-							Image: "busybox",
-							Command: []string{
-								"sleep",
-								"86400", // 1 day
-							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									"memory": memoryRequest,
-									"cpu":    resource.MustParse("500m"),
-								},
-							},
-						},
-					},
-					RestartPolicy: corev1.RestartPolicy("Never"),
-					Tolerations: []corev1.Toleration{
-						{
-							Key:      "kubemark",
-							Operator: corev1.TolerationOpExists,
-						},
-					},
-				},
-			},
-			BackoffLimit: pointer.Int32Ptr(4),
-			Completions:  pointer.Int32Ptr(njobs),
-			Parallelism:  pointer.Int32Ptr(njobs),
-		},
-	}
-	if nodeSelector != "" {
-		job.Spec.Template.Spec.NodeSelector = map[string]string{
-			nodeSelector: "",
-		}
-	}
-	return job
-}
 
 // Build default CA resource to allow fast scaling up and down
 func clusterAutoscalerResource(maxNodesTotal int) *caov1.ClusterAutoscaler {
@@ -332,7 +279,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			cleanupObjects[asr.GetName()] = asr
 
 			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s", expectedReplicas, workloadMemRequest.String()))
-			workload := newWorkLoad(expectedReplicas, workloadMemRequest, targetedNodeLabel)
+			workload := framework.NewWorkLoad(expectedReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -393,7 +340,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			jobReplicas := expectedReplicas * int32(2)
 			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
 				jobReplicas, workloadMemRequest.String()))
-			workload := newWorkLoad(jobReplicas, workloadMemRequest, targetedNodeLabel)
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -546,7 +493,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			jobReplicas := maxMachineSetReplicas
 			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
 				jobReplicas, workloadMemRequest.String()))
-			workload := newWorkLoad(jobReplicas, workloadMemRequest, targetedNodeLabel)
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
@@ -639,7 +586,7 @@ var _ = Describe("[Feature:Machines] Autoscaler should", func() {
 			jobReplicas := int32(4)
 			By(fmt.Sprintf("Creating scale-out workload: jobs: %v, memory: %s",
 				jobReplicas, workloadMemRequest.String()))
-			workload := newWorkLoad(jobReplicas, workloadMemRequest, targetedNodeLabel)
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, workloadJobName, autoscalingTestLabel, targetedNodeLabel, "")
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 

--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -64,11 +64,11 @@ var _ = BeforeSuite(func() {
 	client, err := framework.LoadClient()
 	Expect(err).ToNot(HaveOccurred())
 
-	infra, err := framework.GetInfrastructure(client)
+	platform, err := framework.GetPlatform(client)
 	Expect(err).ToNot(HaveOccurred())
 
 	// Extend timeouts for slower providers
-	switch infra.Status.PlatformStatus.Type {
+	switch platform {
 	case osconfigv1.AzurePlatformType, osconfigv1.VSpherePlatformType, osconfigv1.OpenStackPlatformType:
 		framework.WaitShort = 2 * time.Minute  // Normally 1m
 		framework.WaitMedium = 6 * time.Minute // Normally 3m

--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -15,7 +15,7 @@ import (
 	osconfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
 	caov1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis"
-	mapiv1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/autoscaler"
@@ -30,7 +30,7 @@ func init() {
 	klog.InitFlags(nil)
 	klog.SetOutput(GinkgoWriter)
 
-	if err := mapiv1beta1.AddToScheme(scheme.Scheme); err != nil {
+	if err := machinev1.AddToScheme(scheme.Scheme); err != nil {
 		klog.Fatal(err)
 	}
 

--- a/pkg/e2e_test.go
+++ b/pkg/e2e_test.go
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 
 	// Extend timeouts for slower providers
 	switch infra.Status.PlatformStatus.Type {
-	case osconfigv1.AzurePlatformType, osconfigv1.VSpherePlatformType:
+	case osconfigv1.AzurePlatformType, osconfigv1.VSpherePlatformType, osconfigv1.OpenStackPlatformType:
 		framework.WaitShort = 2 * time.Minute  // Normally 1m
 		framework.WaitMedium = 6 * time.Minute // Normally 3m
 		framework.WaitLong = 30 * time.Minute  // Normally 15m

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -29,12 +29,13 @@ const (
 	RetryMedium             = 5 * time.Second
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil
-	DefaultMachineSetReplicas = 0
-	MachinePhaseRunning       = "Running"
-	MachinePhaseFailed        = "Failed"
-	MachineRoleLabel          = "machine.openshift.io/cluster-api-machine-role"
-	MachineTypeLabel          = "machine.openshift.io/cluster-api-machine-type"
-	MachineAnnotationKey      = "machine.openshift.io/machine"
+	DefaultMachineSetReplicas  = 0
+	MachinePhaseRunning        = "Running"
+	MachinePhaseFailed         = "Failed"
+	MachineRoleLabel           = "machine.openshift.io/cluster-api-machine-role"
+	MachineTypeLabel           = "machine.openshift.io/cluster-api-machine-type"
+	MachineAnnotationKey       = "machine.openshift.io/machine"
+	ClusterAPIActuatorPkgTaint = "cluster-api-actuator-pkg"
 )
 
 var (

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -31,6 +31,7 @@ const (
 	// if MachineSet.Spec.Replicas field is set to nil
 	DefaultMachineSetReplicas = 0
 	MachinePhaseRunning       = "Running"
+	MachinePhaseFailed        = "Failed"
 	MachineRoleLabel          = "machine.openshift.io/cluster-api-machine-role"
 	MachineTypeLabel          = "machine.openshift.io/cluster-api-machine-type"
 	MachineAnnotationKey      = "machine.openshift.io/machine"

--- a/pkg/framework/jobs.go
+++ b/pkg/framework/jobs.go
@@ -1,0 +1,63 @@
+package framework
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func NewWorkLoad(njobs int32, memoryRequest resource.Quantity, workloadJobName string,
+	testLabel string, nodeSelector string, podLabel string) *batchv1.Job {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workloadJobName,
+			Namespace: "default",
+			Labels:    map[string]string{testLabel: ""},
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  workloadJobName,
+							Image: "busybox",
+							Command: []string{
+								"sleep",
+								"86400", // 1 day
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"memory": memoryRequest,
+									"cpu":    resource.MustParse("500m"),
+								},
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicy("Never"),
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "kubemark",
+							Operator: corev1.TolerationOpExists,
+						},
+					},
+				},
+			},
+			BackoffLimit: pointer.Int32Ptr(4),
+			Completions:  pointer.Int32Ptr(njobs),
+			Parallelism:  pointer.Int32Ptr(njobs),
+		},
+	}
+	if nodeSelector != "" {
+		job.Spec.Template.Spec.NodeSelector = map[string]string{
+			nodeSelector: "",
+		}
+	}
+	if podLabel != "" {
+		job.Spec.Template.ObjectMeta.Labels = map[string]string{
+			podLabel: "",
+		}
+	}
+	return job
+}

--- a/pkg/framework/jobs.go
+++ b/pkg/framework/jobs.go
@@ -41,6 +41,10 @@ func NewWorkLoad(njobs int32, memoryRequest resource.Quantity, workloadJobName s
 							Key:      "kubemark",
 							Operator: corev1.TolerationOpExists,
 						},
+						{
+							Key:    ClusterAPIActuatorPkgTaint,
+							Effect: corev1.TaintEffectPreferNoSchedule,
+						},
 					},
 				},
 			},

--- a/pkg/framework/jobs.go
+++ b/pkg/framework/jobs.go
@@ -13,7 +13,7 @@ func NewWorkLoad(njobs int32, memoryRequest resource.Quantity, workloadJobName s
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workloadJobName,
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 			Labels:    map[string]string{testLabel: ""},
 		},
 		Spec: batchv1.JobSpec{

--- a/pkg/framework/machinehealthcheck.go
+++ b/pkg/framework/machinehealthcheck.go
@@ -3,7 +3,7 @@ package framework
 import (
 	"context"
 
-	mapiv1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,13 +14,13 @@ import (
 type MachineHealthCheckParams struct {
 	Name         string
 	Labels       map[string]string
-	Conditions   []mapiv1beta1.UnhealthyCondition
+	Conditions   []machinev1.UnhealthyCondition
 	MaxUnhealthy *int
 }
 
 // CreateMHC creates a new MachineHealthCheck resource.
-func CreateMHC(c client.Client, params MachineHealthCheckParams) (*mapiv1beta1.MachineHealthCheck, error) {
-	mhc := &mapiv1beta1.MachineHealthCheck{
+func CreateMHC(c client.Client, params MachineHealthCheckParams) (*machinev1.MachineHealthCheck, error) {
+	mhc := &machinev1.MachineHealthCheck{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machine.openshift.io/v1beta1",
 			Kind:       "MachineHealthCheck",
@@ -29,7 +29,7 @@ func CreateMHC(c client.Client, params MachineHealthCheckParams) (*mapiv1beta1.M
 			Name:      params.Name,
 			Namespace: MachineAPINamespace,
 		},
-		Spec: mapiv1beta1.MachineHealthCheckSpec{
+		Spec: machinev1.MachineHealthCheckSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: params.Labels,
 			},

--- a/pkg/framework/machines.go
+++ b/pkg/framework/machines.go
@@ -19,18 +19,24 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// FilterRunningMachines returns a slice of only those Machines in the input
-// that are in the "Running" phase.
-func FilterRunningMachines(machines []*machinev1.Machine) []*machinev1.Machine {
+// FilterMachines returns a slice of only those Machines in the input that are
+// in the requested phase.
+func FilterMachines(machines []*machinev1.Machine, phase string) []*machinev1.Machine {
 	var result []*machinev1.Machine
 
 	for i, m := range machines {
-		if m.Status.Phase != nil && *m.Status.Phase == MachinePhaseRunning {
+		if m.Status.Phase != nil && *m.Status.Phase == phase {
 			result = append(result, machines[i])
 		}
 	}
 
 	return result
+}
+
+// FilterRunningMachines returns a slice of only those Machines in the input
+// that are in the "Running" phase.
+func FilterRunningMachines(machines []*machinev1.Machine) []*machinev1.Machine {
+	return FilterMachines(machines, MachinePhaseRunning)
 }
 
 // GetMachine get a machine by its name from the default machine API namespace.

--- a/pkg/framework/machines.go
+++ b/pkg/framework/machines.go
@@ -7,7 +7,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	mapiv1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,8 +21,8 @@ import (
 
 // FilterRunningMachines returns a slice of only those Machines in the input
 // that are in the "Running" phase.
-func FilterRunningMachines(machines []*mapiv1beta1.Machine) []*mapiv1beta1.Machine {
-	var result []*mapiv1beta1.Machine
+func FilterRunningMachines(machines []*machinev1.Machine) []*machinev1.Machine {
+	var result []*machinev1.Machine
 
 	for i, m := range machines {
 		if m.Status.Phase != nil && *m.Status.Phase == MachinePhaseRunning {
@@ -34,8 +34,8 @@ func FilterRunningMachines(machines []*mapiv1beta1.Machine) []*mapiv1beta1.Machi
 }
 
 // GetMachine get a machine by its name from the default machine API namespace.
-func GetMachine(c client.Client, name string) (*mapiv1beta1.Machine, error) {
-	machine := &mapiv1beta1.Machine{}
+func GetMachine(c client.Client, name string) (*machinev1.Machine, error) {
+	machine := &machinev1.Machine{}
 	key := client.ObjectKey{Namespace: MachineAPINamespace, Name: name}
 
 	if err := c.Get(context.Background(), key, machine); err != nil {
@@ -47,7 +47,7 @@ func GetMachine(c client.Client, name string) (*mapiv1beta1.Machine, error) {
 
 // MachinesPresent search for each provided machine in `machines` argument in the predefined `existingMachines` list
 // and returns true when all of them were found
-func MachinesPresent(existingMachines []*mapiv1beta1.Machine, machines ...*mapiv1beta1.Machine) bool {
+func MachinesPresent(existingMachines []*machinev1.Machine, machines ...*machinev1.Machine) bool {
 	if len(existingMachines) < len(machines) {
 		return false
 	}
@@ -65,8 +65,8 @@ func MachinesPresent(existingMachines []*mapiv1beta1.Machine, machines ...*mapiv
 
 // GetMachines gets a list of machinesets from the default machine API namespace.
 // Optionaly, labels may be used to constrain listed machinesets.
-func GetMachines(client runtimeclient.Client, selectors ...*metav1.LabelSelector) ([]*mapiv1beta1.Machine, error) {
-	machineList := &mapiv1beta1.MachineList{}
+func GetMachines(client runtimeclient.Client, selectors ...*metav1.LabelSelector) ([]*machinev1.Machine, error) {
+	machineList := &machinev1.MachineList{}
 
 	listOpts := append([]runtimeclient.ListOption{},
 		runtimeclient.InNamespace(MachineAPINamespace),
@@ -87,7 +87,7 @@ func GetMachines(client runtimeclient.Client, selectors ...*metav1.LabelSelector
 		return nil, fmt.Errorf("error querying api for machineList object: %w", err)
 	}
 
-	var machines []*mapiv1beta1.Machine
+	var machines []*machinev1.Machine
 
 	for i := range machineList.Items {
 		machines = append(machines, &machineList.Items[i])
@@ -97,7 +97,7 @@ func GetMachines(client runtimeclient.Client, selectors ...*metav1.LabelSelector
 }
 
 // GetMachineFromNode returns the Machine associated with the given node.
-func GetMachineFromNode(client runtimeclient.Client, node *corev1.Node) (*mapiv1beta1.Machine, error) {
+func GetMachineFromNode(client runtimeclient.Client, node *corev1.Node) (*machinev1.Machine, error) {
 	machineNamespaceKey, ok := node.Annotations[MachineAnnotationKey]
 	if !ok {
 		return nil, fmt.Errorf("node %q does not have a MachineAnnotationKey %q",
@@ -123,7 +123,7 @@ func GetMachineFromNode(client runtimeclient.Client, node *corev1.Node) (*mapiv1
 }
 
 // DeleteMachines deletes the specified machines and returns an error on failure.
-func DeleteMachines(client runtimeclient.Client, machines ...*mapiv1beta1.Machine) error {
+func DeleteMachines(client runtimeclient.Client, machines ...*machinev1.Machine) error {
 	return wait.PollImmediate(RetryShort, time.Minute, func() (bool, error) {
 		for _, machine := range machines {
 			if err := client.Delete(context.TODO(), machine); err != nil {
@@ -136,13 +136,13 @@ func DeleteMachines(client runtimeclient.Client, machines ...*mapiv1beta1.Machin
 }
 
 // WaitForMachinesDeleted polls until the given Machines are not found.
-func WaitForMachinesDeleted(c client.Client, machines ...*mapiv1beta1.Machine) {
+func WaitForMachinesDeleted(c client.Client, machines ...*machinev1.Machine) {
 	Eventually(func() bool {
 		for _, m := range machines {
 			err := c.Get(context.Background(), client.ObjectKey{
 				Name:      m.GetName(),
 				Namespace: m.GetNamespace(),
-			}, &mapiv1beta1.Machine{})
+			}, &machinev1.Machine{})
 			if !apierrors.IsNotFound(err) {
 				return false // Not deleted, or other error.
 			}

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,6 +29,7 @@ type MachineSetParams struct {
 	Name         string
 	Replicas     int32
 	Labels       map[string]string
+	Taints       []corev1.Taint
 	ProviderSpec *machinev1.ProviderSpec
 }
 
@@ -59,6 +61,12 @@ func BuildMachineSetParams(client runtimeclient.Client, replicas int) MachineSet
 			"e2e.openshift.io": uid.String(),
 			ClusterKey:         clusterName,
 		},
+		Taints: []corev1.Taint{
+			corev1.Taint{
+				Key:    ClusterAPIActuatorPkgTaint,
+				Effect: corev1.TaintEffectPreferNoSchedule,
+			},
+		},
 	}
 }
 
@@ -87,6 +95,7 @@ func CreateMachineSet(c client.Client, params MachineSetParams) (*machinev1.Mach
 						Labels: params.Labels,
 					},
 					ProviderSpec: *params.ProviderSpec,
+					Taints:       params.Taints,
 				},
 			},
 			Replicas: pointer.Int32Ptr(params.Replicas),

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -398,15 +398,16 @@ func WaitForMachineSetsDeleted(c runtimeclient.Client, machineSets ...*machinev1
 				return fmt.Errorf("%d Machines still present for MachineSet %s", len(machines), ms.GetName())
 			}
 
-			if err := c.Get(context.Background(), runtimeclient.ObjectKey{
+			machineSetErr := c.Get(context.Background(), runtimeclient.ObjectKey{
 				Name:      ms.GetName(),
 				Namespace: ms.GetNamespace(),
-			}, &machinev1.MachineSet{}); err != nil && !apierrors.IsNotFound(err) {
+			}, &machinev1.MachineSet{})
+			if machineSetErr != nil && !apierrors.IsNotFound(machineSetErr) {
 				return fmt.Errorf("could not fetch MachineSet %s: %v", ms.GetName(), err)
 			}
 
 			// No error means the MachineSet still exists.
-			if err == nil {
+			if machineSetErr == nil {
 				return fmt.Errorf("MachineSet %s still present, but has no Machines", ms.GetName())
 			}
 

--- a/pkg/framework/nodes.go
+++ b/pkg/framework/nodes.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	mapiv1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +63,7 @@ func GetNodes(c client.Client, selectors ...*metav1.LabelSelector) ([]corev1.Nod
 }
 
 // GetNodesFromMachineSet returns an array of nodes backed by machines owned by a given machineSet
-func GetNodesFromMachineSet(client runtimeclient.Client, machineSet *mapiv1beta1.MachineSet) ([]*corev1.Node, error) {
+func GetNodesFromMachineSet(client runtimeclient.Client, machineSet *machinev1.MachineSet) ([]*corev1.Node, error) {
 	machines, err := GetMachinesFromMachineSet(client, machineSet)
 	if err != nil {
 		return nil, fmt.Errorf("error calling getMachinesFromMachineSet %w", err)
@@ -87,7 +87,7 @@ func GetNodesFromMachineSet(client runtimeclient.Client, machineSet *mapiv1beta1
 }
 
 // GetNodeForMachine retrieves the node backing the given Machine.
-func GetNodeForMachine(c client.Client, m *mapiv1beta1.Machine) (*corev1.Node, error) {
+func GetNodeForMachine(c client.Client, m *machinev1.Machine) (*corev1.Node, error) {
 	if m.Status.NodeRef == nil {
 		return nil, fmt.Errorf("%s: machine has no NodeRef", m.Name)
 	}
@@ -140,11 +140,11 @@ func NodesAreReady(nodes []*corev1.Node) bool {
 	return true
 }
 
-func VerifyNodeDraining(client runtimeclient.Client, targetMachine *mapiv1beta1.Machine, rc *corev1.ReplicationController) (string, error) {
+func VerifyNodeDraining(client runtimeclient.Client, targetMachine *machinev1.Machine, rc *corev1.ReplicationController) (string, error) {
 	endTime := time.Now().Add(time.Duration(WaitLong))
 	var drainedNodeName string
 	err := wait.PollImmediate(RetryMedium, WaitLong, func() (bool, error) {
-		machine := mapiv1beta1.Machine{}
+		machine := machinev1.Machine{}
 
 		key := types.NamespacedName{
 			Namespace: targetMachine.Namespace,

--- a/pkg/framework/pods.go
+++ b/pkg/framework/pods.go
@@ -1,9 +1,13 @@
 package framework
 
 import (
+	"bytes"
 	"context"
+	"io"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -12,4 +16,55 @@ func GetPods(client runtimeclient.Client, selector map[string]string) (*corev1.P
 	pods := &corev1.PodList{}
 	err := client.List(context.TODO(), pods, runtimeclient.MatchingLabels(selector))
 	return pods, err
+}
+
+type PodCleanupFunc func() error
+
+type PodLastLogFunc func(container string, lines int, previous bool) (string, error)
+
+// RunPodOnNode runs a pod according passed spec on particular node.
+// returns created pod object, function for retrieve last logs, cleanup function and error if occurred
+func RunPodOnNode(clientset *kubernetes.Clientset, node *corev1.Node, namespace string, podSpec corev1.PodSpec) (*corev1.Pod, PodLastLogFunc, PodCleanupFunc, error) {
+	var err error
+	podSpec.NodeName = node.Name
+	pod := &corev1.Pod{
+		Spec: podSpec,
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "machine-api-e2e-",
+		},
+	}
+
+	pod, err = clientset.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	cleanup := func() error {
+		return clientset.CoreV1().Pods(namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+	}
+
+	lastLog := func(container string, lines int, previous bool) (string, error) {
+		tailLines := int64(lines)
+		req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+			Container: container,
+			Follow:    true,
+			Previous:  previous,
+			TailLines: &tailLines,
+		})
+		podLogs, err := req.Stream(context.TODO())
+		if err != nil {
+			return "", err
+		}
+		defer podLogs.Close()
+		buf := new(bytes.Buffer)
+		_, err = io.Copy(buf, podLogs)
+		if err != nil {
+			return "", err
+		}
+		logs := buf.String()
+
+		return logs, nil
+	}
+
+	return pod, lastLog, cleanup, err
 }

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -15,12 +15,11 @@ import (
 )
 
 const proxySetup = `
-cd /root
-mkdir /root/.mitmproxy
-cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem
+cd /.mitmproxy
+cat /root/certs/tls.key /root/certs/tls.crt > /.mitmproxy/mitmproxy-ca.pem
 curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
 tar xvf mitmproxy-5.3.0-linux.tar.gz
-./mitmdump
+HOME=/.mitmproxy ./mitmdump
 `
 
 const mitmSignerCert = `
@@ -144,6 +143,12 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 								},
 							},
 						},
+						{
+							Name: "mitm-workdir",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -166,6 +171,11 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 									Name:      "mitm-signer",
 									ReadOnly:  false,
 									MountPath: "/root/certs",
+								},
+								{
+									Name:      "mitm-workdir",
+									ReadOnly:  false,
+									MountPath: "/.mitmproxy",
 								},
 							},
 						},

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -16,10 +16,10 @@ import (
 const proxySetup = `
 cd /root
 mkdir /root/.mitmproxy
-cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem  
+cat /root/certs/tls.key /root/certs/tls.crt > /root/.mitmproxy/mitmproxy-ca.pem
 curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
 tar xvf mitmproxy-5.3.0-linux.tar.gz
-./mitmdump 
+./mitmdump
 `
 
 const mitmSignerCert = `
@@ -65,14 +65,14 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      "mitm-proxy",
-		Namespace: "default",
+		Namespace: MachineAPINamespace,
 		Labels:    mitmDeploymentLabels,
 	}
 
 	mitmSigner := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-signer",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 			Labels:    mitmDeploymentLabels,
 		},
 		Data: map[string][]byte{
@@ -87,7 +87,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	mitmBootstrapConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-bootstrap",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 		Data: map[string]string{
 			"startup.sh": proxySetup,
@@ -178,7 +178,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 		return err
 	}
 
-	IsDaemonsetAvailable(c, "mitm-proxy", "default")
+	IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace)
 
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
@@ -199,7 +199,7 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	if err != nil {
 		return err
 	}
-	IsServiceAvailable(c, "mitm-proxy", "default")
+	IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace)
 
 	return err
 }
@@ -212,14 +212,14 @@ func DestroyClusterProxy(c runtimeclient.Client) error {
 
 	mitmObjectMeta := metav1.ObjectMeta{
 		Name:      "mitm-proxy",
-		Namespace: "default",
+		Namespace: MachineAPINamespace,
 		Labels:    mitmDeploymentLabels,
 	}
 
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-bootstrap",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 	}
 	err := c.Delete(context.Background(), configMap)
@@ -241,7 +241,7 @@ func DestroyClusterProxy(c runtimeclient.Client) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mitm-signer",
-			Namespace: "default",
+			Namespace: MachineAPINamespace,
 		},
 	}
 	err = c.Delete(context.Background(), secret)

--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -178,7 +179,9 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 		return err
 	}
 
-	IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace)
+	if !IsDaemonsetAvailable(c, objectMeta.Name, objectMeta.Namespace) {
+		return errors.New("daemonset did not become available")
+	}
 
 	service := &corev1.Service{
 		ObjectMeta: objectMeta,
@@ -199,7 +202,9 @@ func DeployClusterProxy(c runtimeclient.Client) error {
 	if err != nil {
 		return err
 	}
-	IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace)
+	if !IsServiceAvailable(c, objectMeta.Name, objectMeta.Namespace) {
+		return errors.New("service did not become available")
+	}
 
 	return err
 }

--- a/pkg/framework/webhooks.go
+++ b/pkg/framework/webhooks.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	webhooks "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -14,10 +14,10 @@ import (
 )
 
 // DefaultValidatingWebhookConfiguration is a default validating webhook configuration resource provided by MAO
-var DefaultValidatingWebhookConfiguration = mapiv1.NewValidatingWebhookConfiguration()
+var DefaultValidatingWebhookConfiguration = webhooks.NewValidatingWebhookConfiguration()
 
 // DefaultMutatingWebhookConfiguration is a default mutating webhook configuration resource provided by MAO
-var DefaultMutatingWebhookConfiguration = mapiv1.NewMutatingWebhookConfiguration()
+var DefaultMutatingWebhookConfiguration = webhooks.NewMutatingWebhookConfiguration()
 
 // GetMutatingWebhookConfiguration gets MutatingWebhookConfiguration object by name
 func GetMutatingWebhookConfiguration(c client.Client, name string) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -49,7 +49,7 @@ func replicationControllerWorkload(namespace string) *corev1.ReplicationControll
 					Containers: []corev1.Container{
 						{
 							Name:    "work",
-							Image:   "busybox",
+							Image:   "registry.ci.openshift.org/openshift/origin-v4.0:base",
 							Command: []string{"sleep", "10h"},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -151,7 +151,7 @@ var _ = Describe("[Feature:Machines] Managed cluster should", func() {
 		client, err = framework.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
 
-		machineSetParams = framework.BuildMachineSetParams(client, 3)
+		machineSetParams = framework.BuildMachineSetParams(client, 2)
 
 		By("Creating a new MachineSet")
 		machineSet, err = framework.CreateMachineSet(client, machineSetParams)

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
-	mapiv1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	kpolicyapi "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -90,30 +90,30 @@ func podDisruptionBudget(namespace string) *kpolicyapi.PodDisruptionBudget {
 	}
 }
 
-func invalidMachinesetWithEmptyProviderConfig() *mapiv1beta1.MachineSet {
+func invalidMachinesetWithEmptyProviderConfig() *machinev1.MachineSet {
 	var oneReplicas int32 = 1
-	return &mapiv1beta1.MachineSet{
+	return &machinev1.MachineSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalid-machineset",
 			Namespace: framework.MachineAPINamespace,
 		},
-		Spec: mapiv1beta1.MachineSetSpec{
+		Spec: machinev1.MachineSetSpec{
 			Replicas: &oneReplicas,
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"little-kitty": "i-am-little-kitty",
 				},
 			},
-			Template: mapiv1beta1.MachineTemplateSpec{
-				ObjectMeta: mapiv1beta1.ObjectMeta{
+			Template: machinev1.MachineTemplateSpec{
+				ObjectMeta: machinev1.ObjectMeta{
 					Labels: map[string]string{
 						"big-kitty": "i-am-bit-kitty",
 					},
 				},
-				Spec: mapiv1beta1.MachineSpec{
+				Spec: machinev1.MachineSpec{
 					// Empty providerSpec!!! we don't want to provision real instances.
 					// Just to observe how many machine replicas get created.
-					ProviderSpec: mapiv1beta1.ProviderSpec{},
+					ProviderSpec: machinev1.ProviderSpec{},
 				},
 			},
 		},
@@ -142,7 +142,7 @@ var _ = Describe("[Feature:Machines] Managed cluster should", func() {
 	defer GinkgoRecover()
 
 	var client runtimeclient.Client
-	var machineSet *mapiv1beta1.MachineSet
+	var machineSet *machinev1.MachineSet
 	var machineSetParams framework.MachineSetParams
 
 	BeforeEach(func() {

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -289,13 +289,18 @@ var _ = Describe("[Feature:Machines] Managed cluster should", func() {
 		}()
 
 		By("Creating RC with workload")
-		rc := replicationControllerWorkload("default")
+
+		// Use the openshift-machine-api namespace as it is excluded from
+		// Pod security admission checks.
+		namespace := framework.MachineAPINamespace
+
+		rc := replicationControllerWorkload(namespace)
 		err = client.Create(context.TODO(), rc)
 		Expect(err).NotTo(HaveOccurred())
 		delObjects["rc"] = rc
 
 		By("Creating PDB for RC")
-		pdb := podDisruptionBudget("default")
+		pdb := podDisruptionBudget(namespace)
 		err = client.Create(context.TODO(), pdb)
 		Expect(err).NotTo(HaveOccurred())
 		delObjects["pdb"] = pdb

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -75,7 +75,24 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 	})
 
 	AfterEach(func() {
-		Expect(deleteObjects(client, delObjects)).To(Succeed())
+		var machineSets []*machinev1.MachineSet
+
+		for _, obj := range delObjects {
+			if machineSet, ok := obj.(*machinev1.MachineSet); ok {
+				// Once we delete a MachineSet we should make sure that the
+				// all of its machines are deleted as well.
+				// Collect MachineSets to wait for.
+				machineSets = append(machineSets, machineSet)
+			}
+
+			Expect(deleteObject(client, obj)).To(Succeed())
+		}
+
+		if len(machineSets) > 0 {
+			// Wait for all MachineSets and their Machines to be deleted.
+			By("Waiting for MachineSets to be deleted...")
+			framework.WaitForMachineSetsDeleted(client, machineSets...)
+		}
 	})
 
 	It("should handle the spot instances", func() {

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -45,12 +45,16 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 		var err error
 		client, err = framework.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
-		// Only run on AWS
+
 		platform, err = framework.GetPlatform(client)
 		Expect(err).NotTo(HaveOccurred())
 		switch platform {
 		case configv1.AWSPlatformType, configv1.AzurePlatformType:
-			// Do Nothing
+			// The failure rate of this test has increased significantly on Azure and AWS.
+			// We are seeing a massive spike in not being able to create instances due to
+			// a lack of capacity on the platform.
+			// Skip the test until we have time to work out how to mitigate this.
+			Skip("This test has a high failure rate, skipping until further notice")
 		case configv1.GCPPlatformType:
 			// TODO: GCP relies on the metadata IP for DNS.
 			// This test prevents it from accessing the DNS, therefore

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -13,7 +13,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
 	gcproviderconfigv1 "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
-	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -31,7 +31,7 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 	var ctx = context.Background()
 
 	var client runtimeclient.Client
-	var machineSet *mapiv1.MachineSet
+	var machineSet *machinev1.MachineSet
 	var machineSetParams framework.MachineSetParams
 	var platform configv1.PlatformType
 
@@ -160,7 +160,7 @@ var _ = Describe("[Feature:Machines] Running on Spot", func() {
 				Expect(framework.IsDeploymentAvailable(client, deployment.Name, deployment.Namespace)).To(BeTrue())
 			})
 
-			var machine *mapiv1.Machine
+			var machine *machinev1.Machine
 			By("Choosing a Machine to terminate", func() {
 				machines, err := framework.GetMachinesFromMachineSet(client, machineSet)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -233,26 +233,17 @@ func minimalGCPProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, erro
 }
 
 func minimalVSphereProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, error) {
-	fullProviderSpec := &vsphere.VSphereMachineProviderSpec{}
-	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
+	providerSpec := &vsphere.VSphereMachineProviderSpec{}
+	err := json.Unmarshal(ps.Value.Raw, providerSpec)
 	if err != nil {
 		return nil, err
 	}
+	// For vSphere only these 2 fields are defaultable
+	providerSpec.UserDataSecret = nil
+	providerSpec.CredentialsSecret = nil
 	return &mapiv1.ProviderSpec{
 		Value: &runtime.RawExtension{
-			Object: &vsphere.VSphereMachineProviderSpec{
-				Template: fullProviderSpec.Template,
-				Workspace: &vsphere.Workspace{
-					Datacenter: fullProviderSpec.Workspace.Datacenter,
-					Server:     fullProviderSpec.Workspace.Server,
-				},
-				Network: vsphere.NetworkSpec{
-					Devices: fullProviderSpec.Network.Devices,
-				},
-				NumCPUs:   fullProviderSpec.NumCPUs,
-				MemoryMiB: fullProviderSpec.MemoryMiB,
-				DiskGiB:   fullProviderSpec.DiskGiB,
-			},
+			Object: providerSpec,
 		},
 	}, nil
 }

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -53,6 +53,16 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 		testSelector = &metav1.LabelSelector{
 			MatchLabels: machineSetParams.Labels,
 		}
+
+		By("Checking the webhook configurations are synced", func() {
+			Eventually(func() bool {
+				return framework.IsMutatingWebhookConfigurationSynced(client)
+			}, framework.WaitShort).Should(BeTrue(), "MutatingWebhookConfiguration must be synced before running these tests")
+
+			Eventually(func() bool {
+				return framework.IsValidatingWebhookConfigurationSynced(client)
+			}, framework.WaitShort).Should(BeTrue(), "ValidingWebhookConfiguration must be synced before running these tests")
+		})
 	})
 
 	AfterEach(func() {

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -10,7 +10,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
 	gcp "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
-	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	vsphere "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,13 +68,13 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 
 	It("should be able to create a machine from a minimal providerSpec", func() {
-		machine := &mapiv1.Machine{
+		machine := &machinev1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-webhook-", machineSetParams.Name),
 				Namespace:    framework.MachineAPINamespace,
 				Labels:       machineSetParams.Labels,
 			},
-			Spec: mapiv1.MachineSpec{
+			Spec: machinev1.MachineSpec{
 				ProviderSpec: *machineSetParams.ProviderSpec,
 			},
 		}
@@ -85,7 +85,7 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 			if err != nil {
 				return err
 			}
-			running := framework.FilterRunningMachines([]*mapiv1.Machine{m})
+			running := framework.FilterRunningMachines([]*machinev1.Machine{m})
 			if len(running) == 0 {
 				return fmt.Errorf("machine not yet running")
 			}
@@ -101,13 +101,13 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 
 	It("should return an error when removing required fields from the Machine providerSpec", func() {
-		machine := &mapiv1.Machine{
+		machine := &machinev1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-webhook-", machineSetParams.Name),
 				Namespace:    framework.MachineAPINamespace,
 				Labels:       machineSetParams.Labels,
 			},
-			Spec: mapiv1.MachineSpec{
+			Spec: machinev1.MachineSpec{
 				ProviderSpec: *machineSetParams.ProviderSpec,
 			},
 		}
@@ -163,7 +163,7 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 })
 
-func createMinimalProviderSpec(platform configv1.PlatformType, ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, error) {
+func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
 	switch platform {
 	case configv1.AWSPlatformType:
 		return minimalAWSProviderSpec(ps)
@@ -179,13 +179,13 @@ func createMinimalProviderSpec(platform configv1.PlatformType, ps *mapiv1.Provid
 	}
 }
 
-func minimalAWSProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, error) {
+func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
 	fullProviderSpec := &aws.AWSMachineProviderConfig{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &mapiv1.ProviderSpec{
+	return &machinev1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: &aws.AWSMachineProviderConfig{
 				AMI:                fullProviderSpec.AMI,
@@ -197,13 +197,13 @@ func minimalAWSProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, erro
 	}, nil
 }
 
-func minimalAzureProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, error) {
+func minimalAzureProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
 	fullProviderSpec := &azure.AzureMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &mapiv1.ProviderSpec{
+	return &machinev1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: &azure.AzureMachineProviderSpec{
 				Location: fullProviderSpec.Location,
@@ -215,13 +215,13 @@ func minimalAzureProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, er
 	}, nil
 }
 
-func minimalGCPProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, error) {
+func minimalGCPProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
 	fullProviderSpec := &gcp.GCPMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &mapiv1.ProviderSpec{
+	return &machinev1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: &gcp.GCPMachineProviderSpec{
 				Region:          fullProviderSpec.Region,
@@ -232,7 +232,7 @@ func minimalGCPProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, erro
 	}, nil
 }
 
-func minimalVSphereProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, error) {
+func minimalVSphereProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
 	providerSpec := &vsphere.VSphereMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, providerSpec)
 	if err != nil {
@@ -241,7 +241,7 @@ func minimalVSphereProviderSpec(ps *mapiv1.ProviderSpec) (*mapiv1.ProviderSpec, 
 	// For vSphere only these 2 fields are defaultable
 	providerSpec.UserDataSecret = nil
 	providerSpec.CredentialsSecret = nil
-	return &mapiv1.ProviderSpec{
+	return &machinev1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: providerSpec,
 		},

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -10,7 +10,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
 	gcp "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
-	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	vsphere "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,13 +68,13 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 
 	It("should be able to create a machine from a minimal providerSpec", func() {
-		machine := &machinev1.Machine{
+		machine := &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-webhook-", machineSetParams.Name),
 				Namespace:    framework.MachineAPINamespace,
 				Labels:       machineSetParams.Labels,
 			},
-			Spec: machinev1.MachineSpec{
+			Spec: machinev1beta1.MachineSpec{
 				ProviderSpec: *machineSetParams.ProviderSpec,
 			},
 		}
@@ -85,7 +85,7 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 			if err != nil {
 				return err
 			}
-			running := framework.FilterRunningMachines([]*machinev1.Machine{m})
+			running := framework.FilterRunningMachines([]*machinev1beta1.Machine{m})
 			if len(running) == 0 {
 				return fmt.Errorf("machine not yet running")
 			}
@@ -101,13 +101,13 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 
 	It("should return an error when removing required fields from the Machine providerSpec", func() {
-		machine := &machinev1.Machine{
+		machine := &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-webhook-", machineSetParams.Name),
 				Namespace:    framework.MachineAPINamespace,
 				Labels:       machineSetParams.Labels,
 			},
-			Spec: machinev1.MachineSpec{
+			Spec: machinev1beta1.MachineSpec{
 				ProviderSpec: *machineSetParams.ProviderSpec,
 			},
 		}
@@ -163,7 +163,7 @@ var _ = Describe("[Feature:Machines] Webhooks", func() {
 	})
 })
 
-func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
+func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
 	switch platform {
 	case configv1.AWSPlatformType:
 		return minimalAWSProviderSpec(ps)
@@ -179,13 +179,13 @@ func createMinimalProviderSpec(platform configv1.PlatformType, ps *machinev1.Pro
 	}
 }
 
-func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
+func minimalAWSProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
 	fullProviderSpec := &aws.AWSMachineProviderConfig{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: &aws.AWSMachineProviderConfig{
 				AMI:                fullProviderSpec.AMI,
@@ -198,13 +198,13 @@ func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec
 	}, nil
 }
 
-func minimalAzureProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
+func minimalAzureProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
 	fullProviderSpec := &azure.AzureMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: &azure.AzureMachineProviderSpec{
 				Location: fullProviderSpec.Location,
@@ -216,13 +216,13 @@ func minimalAzureProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSp
 	}, nil
 }
 
-func minimalGCPProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
+func minimalGCPProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
 	fullProviderSpec := &gcp.GCPMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, fullProviderSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: &gcp.GCPMachineProviderSpec{
 				Region:          fullProviderSpec.Region,
@@ -233,7 +233,7 @@ func minimalGCPProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec
 	}, nil
 }
 
-func minimalVSphereProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec, error) {
+func minimalVSphereProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.ProviderSpec, error) {
 	providerSpec := &vsphere.VSphereMachineProviderSpec{}
 	err := json.Unmarshal(ps.Value.Raw, providerSpec)
 	if err != nil {
@@ -242,7 +242,7 @@ func minimalVSphereProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.Provider
 	// For vSphere only these 2 fields are defaultable
 	providerSpec.UserDataSecret = nil
 	providerSpec.CredentialsSecret = nil
-	return &machinev1.ProviderSpec{
+	return &machinev1beta1.ProviderSpec{
 		Value: &runtime.RawExtension{
 			Object: providerSpec,
 		},

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -192,6 +192,7 @@ func minimalAWSProviderSpec(ps *machinev1.ProviderSpec) (*machinev1.ProviderSpec
 				Placement:          fullProviderSpec.Placement,
 				Subnet:             *fullProviderSpec.Subnet.DeepCopy(),
 				IAMInstanceProfile: fullProviderSpec.IAMInstanceProfile.DeepCopy(),
+				SecurityGroups:     fullProviderSpec.SecurityGroups,
 			},
 		},
 	}, nil

--- a/pkg/machinehealthcheck/machinehealthcheck.go
+++ b/pkg/machinehealthcheck/machinehealthcheck.go
@@ -20,8 +20,8 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck", func() {
 
 	var machineSet *mapiv1beta1.MachineSet
 	var machinehealthcheck *v1beta1.MachineHealthCheck
-	var maxUnhealthy = 3
-	const expectedReplicas = 5
+	var maxUnhealthy = 2
+	const expectedReplicas = 4
 
 	const E2EConditionType = "MachineHealthCheckE2E"
 

--- a/pkg/machinehealthcheck/machinehealthcheck.go
+++ b/pkg/machinehealthcheck/machinehealthcheck.go
@@ -8,8 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
-	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	mapiv1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,8 +17,8 @@ import (
 var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck", func() {
 	var client client.Client
 
-	var machineSet *mapiv1beta1.MachineSet
-	var machinehealthcheck *v1beta1.MachineHealthCheck
+	var machineSet *machinev1.MachineSet
+	var machinehealthcheck *machinev1.MachineHealthCheck
 	var maxUnhealthy = 2
 	const expectedReplicas = 4
 
@@ -77,7 +76,7 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck", func() {
 		mhcParams := framework.MachineHealthCheckParams{
 			Name:   machineSet.Name,
 			Labels: machineSet.Labels,
-			Conditions: []mapiv1beta1.UnhealthyCondition{
+			Conditions: []machinev1.UnhealthyCondition{
 				{
 					Type:    E2EConditionType,
 					Status:  corev1.ConditionTrue,
@@ -127,7 +126,7 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck", func() {
 		mhcParams := framework.MachineHealthCheckParams{
 			Name:   machineSet.Name,
 			Labels: machineSet.Labels,
-			Conditions: []mapiv1beta1.UnhealthyCondition{
+			Conditions: []machinev1.UnhealthyCondition{
 				{
 					Type:    E2EConditionType,
 					Status:  corev1.ConditionTrue,

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -253,9 +253,6 @@ var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide prox
 
 		By("waiting for machine-api-controller deployment to reflect unconfigured cluster-wide proxy")
 		Expect(framework.WaitForProxyInjectionSync(client, maoManagedDeployment, framework.MachineAPINamespace, false)).To(BeTrue())
-
-		err = framework.DestroyClusterProxy(client)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -270,5 +267,8 @@ var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide prox
 		By("waiting for KCM cluster operator to become available")
 		Expect(framework.WaitForStatusAvailableOverLong(client, "kube-controller-manager")).To(BeTrue())
 		Expect(framework.WaitForStatusAvailableMedium(client, "machine-api")).To(BeTrue())
+
+		By("Removing the mitm-proxy")
+		Expect(framework.DestroyClusterProxy(client)).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -20,7 +20,7 @@ var (
 	maoManagedDeployment = "machine-api-controllers"
 )
 
-var _ = Describe("[Feature:Operators] Machine API operator deployment should", func() {
+var _ = Describe("[Feature:Operators][Disruptive] Machine API operator deployment should", func() {
 	defer GinkgoRecover()
 
 	It("be available", func() {

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -207,6 +207,13 @@ var _ = Describe("[Feature:Operators] Machine API cluster operator status should
 
 var _ = Describe("[Serial][Feature:Operators][Disruptive] When cluster-wide proxy is configured, Machine API cluster operator should ", func() {
 	It("create machines when configured behind a proxy", func() {
+		// This test case takes upwards of 20 minutes to complete.
+		// This test cannot be run in parallel with other tests and as such,
+		// this test has a very high cost associated with it.
+		// The pass rate of this test is normally very good, so we can skip
+		// for now until we are able to move this into a periodic job.
+		Skip("This test is disruptive, slow and expensive. It should only be run periodically and not on presubmits. Skipping until we set up periodics")
+
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
This PR backports various improvements to the package back into release-4.9.

Some notable changes that differ from a plain cherry-pick of all commits:

1) [[4.9 backport] machinev1 to machinev1beta1 changes](https://github.com/openshift/cluster-api-actuator-pkg/commit/2fcfd35138eca51750e82b8e5a8784a8fee0016b)
    Modified version of the original:
    - Migrate tests to openshift/api from MAO - https://github.com/openshift/cluster-api-actuator-pkg/commit/2be3519893eabd08780b5d96649e2d051d1166b9
    
    to use the new import names
    but keep the old import api path local to the repository, for easier
    merge conflict handling.

2) [backport: pkg/infra cleanup](https://github.com/openshift/cluster-api-actuator-pkg/commit/127c62689438075f34c917ac5054a0bbcb35be1e) is a squashed and fixed up version of:
    ```
    backport: pkg/infra cleanup
    A fixup of 4 commits plus
    removal of unndeded aws IMDSv2 tests (feature not present on 4.10) from backport
    
    | * https://github.com/openshift/cluster-api-actuator-pkg/commit/38d03aac8b59e9d75b967eae0a5bf1c0f4ef7aa6 update error construction in GetPlatform func (6 months ago) <Denis Moiseev>
    | * https://github.com/openshift/cluster-api-actuator-pkg/commit/82e156081765425ce523749f373d577bcba3edf0 Fix broken spot tests, rename helper, small cleanup (6 months ago) <Denis Moiseev>
    | * https://github.com/openshift/cluster-api-actuator-pkg/commit/6547ca3ffc00dfbbf486ff30708635bde07e1f31 AWS IMDSv2 feature tests (6 months ago) <Denis Moiseev>
    | * https://github.com/openshift/cluster-api-actuator-pkg/commit/f5644f407bc8638f2a4a4b94e01f85be9332cda9 Upd openshift/api, revendor (6 months ago) <Denis Moiseev>
    ```

3) [[4.9 backport] machinev1 to machinev1beta1 changes](https://github.com/openshift/cluster-api-actuator-pkg/commit/2fcfd35138eca51750e82b8e5a8784a8fee0016b)     
    fixup version of:
    - machinev1 to machinev1beta1 changes https://github.com/openshift/cluster-api-actuator-pkg/commit/31a05921bbceb66de980480c5e882b4588afdca7
    that accounts for differences in importing paths.

4) [[4.9 backport] refactor pkg/framework + autoscaler.go](https://github.com/openshift/cluster-api-actuator-pkg/commit/6ddd8ab4764c157638c0ce6d26cde1708dbdbbb7) 
    backport of a modified version of:
    - Add E2E test for Machine Deletion Hooks https://github.com/openshift/cluster-api-actuator-pkg/commit/061143d40442f9b18bc9690f910e463be62c9b15
    to include part of the changes brought by the commit, not related to the machine deletion
    hooks, which are not present in 4.9.

6) [[4.9 backport][4.10 backport] Wait for Machines to be deleted before completeing each test case](https://github.com/openshift/cluster-api-actuator-pkg/commit/75b7b2e08827b30b6343b1f88d7aa8ffdcd22c73)
    A fixup backport of:
    - [4.10 backport] Wait for Machines to be deleted before completeing each test case https://github.com/openshift/cluster-api-actuator-pkg/commit/74303bbec0ec46437fc995f6995fb11ca7fc959b
    that doesn't have the changes related to the pkg/infra/lifecyclehooks.go
    file, given that doesn't exist in the 4.9 branch.

7) [[4.9 backport][4.10 backport] update Makefile container image](https://github.com/openshift/cluster-api-actuator-pkg/commit/714ffd17c2bee72ed81a8507ed40c4c5e13fc5a8)
    fixup version of the commit:
    - [4.10 backport] update Makefile container image https://github.com/openshift/cluster-api-actuator-pkg/commit/52f27f7478c9196f47c3e309a1cd4f20f37931ca
    that uses the new registry but keeps the go version at 1.15.

8) [[4.9 backport] add tolerations and taints for autoscaler workload](https://github.com/openshift/cluster-api-actuator-pkg/commit/0f4e7f36501809aaca8d57dc2719c1224679da1d) 
    fixup version of:
    - add tolerations and taints for autoscaler workload https://github.com/openshift/cluster-api-actuator-pkg/commit/c8b3717808b7176e06531cf0b2f09ab4253cde5e
    with the machinev1 import path coherent with version 4.9.