### PR TITLE
OCPCLOUD-1711: Resources and logs gatherer for failed tests

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /bin/
 .idea
+
+_out/

--- a/pkg/framework/gatherer/data-gatherer.go
+++ b/pkg/framework/gatherer/data-gatherer.go
@@ -1,0 +1,117 @@
+package gatherer
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/ginkgo"
+
+	"k8s.io/klog"
+)
+
+const (
+	mapiMachines            = "machines.machine.openshift.io"
+	mapiMachinesets         = "machinesets.machine.openshift.io"
+	controlPlaneMachinesets = "controlplanemachinesets.machine.openshift.io"
+	machineHealthChecks     = "machinehealthchecks.machine.openshift.io"
+
+	machineApproverNamespace = "openshift-cluster-machine-approver"
+)
+
+var namespacedResourceToGather = []string{mapiMachinesets, mapiMachines, controlPlaneMachinesets, machineHealthChecks}
+
+var clusterResourceToGather = []string{"nodes", "clusterautoscaler", "machineautoscaler"}
+
+// StateGatherer MAPI specific wrapper for the CLI helper
+// Intended to provide helper functions for gathering MAPI specific resources as well as related pod logs
+type StateGatherer struct {
+	CLI       *CLI
+	sinceTime time.Time
+
+	testInfo *ginkgo.GinkgoTestDescription
+
+	ctx context.Context
+}
+
+// NewStateGatherer initializes StateGatherer
+func NewStateGatherer(ctx context.Context, ocCLI *CLI, gatherSinceTime time.Time) *StateGatherer {
+	return &StateGatherer{
+		CLI:       ocCLI,
+		sinceTime: gatherSinceTime,
+
+		ctx: ctx,
+	}
+}
+
+// GatherResources helper method to collect MAPI-specific resources such as
+// Machines, MachineSets, Nodes, Autoscalers, and so on.
+// Store files into '%CLI.outputBasePath%/%test_name%/resources'
+func (sg *StateGatherer) GatherResources() error {
+	resourcesSubPath := sg.getSubPath("resources")
+	for _, resource := range namespacedResourceToGather {
+		klog.Infof("gathering %s", resource)
+		if _, err := sg.CLI.Run("get").Args(resource, "-o", "wide").WithSubPath(resourcesSubPath).OutputToFile(fmt.Sprintf("%s", resource)); err != nil {
+			klog.Errorf("%s", err.Error())
+			return err
+		}
+		if _, err := sg.CLI.Run("get").Args(resource, "-o", "yaml").WithSubPath(resourcesSubPath).OutputToFile(fmt.Sprintf("%s_full.yaml", resource)); err != nil {
+			klog.Errorf("%s", err.Error())
+			return err
+		}
+	}
+
+	for _, resource := range clusterResourceToGather {
+		klog.Infof("gathering %s", resource)
+		if _, err := sg.CLI.Run("get").WithoutNamespace().Args(resource, "-o", "wide").WithSubPath(resourcesSubPath).OutputToFile(fmt.Sprintf("%s", resource)); err != nil {
+			klog.Errorf("%s", err.Error())
+			return err
+		}
+		if _, err := sg.CLI.Run("get").WithoutNamespace().Args(resource, "-o", "yaml").WithSubPath(resourcesSubPath).OutputToFile(fmt.Sprintf("%s_full.yaml", resource)); err != nil {
+			klog.Errorf("%s", err.Error())
+			return err
+		}
+	}
+	return nil
+}
+
+// GatherPodLogs collects logs from pods in MAPI-related namespaces since a particular time.
+// Skips file creation if no new logs since time were found there.
+// Store files into '%CLI.outputBasePath%/%test_name%/logs'
+func (sg *StateGatherer) GatherPodLogs() {
+	// TODO dmoiseev: Need to figure out how to collect errors from multiply pods/containers properly and do not
+	// TODO dmoiseev: stop gathering from another pods/containers.
+	// TODO dmoiseev: This does not return error for now.
+	logsSubPath := sg.getSubPath("logs")
+	sg.CLI.WithSubPath(logsSubPath).DumpPodLogsSinceTime(sg.ctx, sg.sinceTime)
+	sg.CLI.WithSubPath(logsSubPath).WithNamespace(machineApproverNamespace).DumpPodLogsSinceTime(sg.ctx, sg.sinceTime)
+}
+
+// GatherAll invokes GatherResources and GatherPodLogs subsequently
+func (sg *StateGatherer) GatherAll() error {
+	err := sg.GatherResources()
+	sg.GatherPodLogs()
+	return err
+}
+
+func (sg *StateGatherer) getSubPath(subPath string) string {
+	if sg.testInfo != nil {
+		return filepath.Join(sg.testInfo.FullTestText, subPath)
+	}
+	return subPath
+}
+
+// WithTestDescription sets ginkgo test description for the StateGatherer instance.
+// This test description uses to extract the test name and store relevant data in a respective sub-folder.
+func (sg StateGatherer) WithTestDescription(description ginkgo.GinkgoTestDescription) *StateGatherer {
+	sg.testInfo = &description
+	return &sg
+}
+
+// WithSinceTime sinceTime parameter for the StateGatherer.
+// Uses to indicate test start time and collect logs only since then.
+func (sg StateGatherer) WithSinceTime(time time.Time) *StateGatherer {
+	sg.sinceTime = time
+	return &sg
+}

--- a/pkg/framework/gatherer/oc-cli.go
+++ b/pkg/framework/gatherer/oc-cli.go
@@ -1,0 +1,240 @@
+package gatherer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CLI provides function to call the OpenShift CLI, which is using to simplify state gathering during tests.
+// This wrapper was inspired by the openshift/origin version of a similar helper.
+// Origin version https://github.com/openshift/origin/blob/1ec0eb3175f25b525abb39253528e230a9a85684/test/extended/util/client.go#L80
+type CLI struct {
+	execPath         string
+	verb             string
+	configPath       string
+	namespace        string
+	token            string
+	outputBasePath   string
+	subPath          string
+	runtimeClient    runtimeclient.Client
+	globalArgs       []string
+	commandArgs      []string
+	finalArgs        []string
+	withoutNamespace bool
+	stdin            *bytes.Buffer
+	stdout           io.Writer
+	stderr           io.Writer
+	verbose          bool
+}
+
+// NewCLI initializes the OC CLI wrapper
+func NewCLI(namespace string, client runtimeclient.Client, outputBasePath string) (*CLI, error) {
+	cli := &CLI{
+		execPath:       "oc",
+		namespace:      namespace,
+		outputBasePath: outputBasePath,
+		runtimeClient:  client,
+		configPath:     kubeConfigPath(),
+		verbose:        true,
+	}
+	return cli, nil
+}
+
+// KubeConfigPath returns the value of KUBECONFIG environment variable
+func kubeConfigPath() string {
+	// can't use gomega in this method since it might be used outside of the tests
+	return os.Getenv("KUBECONFIG")
+}
+
+// setOutput allows to override the default command output
+func (oc *CLI) setOutput(out io.Writer) *CLI {
+	oc.stdout = out
+	return oc
+}
+
+func (oc *CLI) outputs(stdOutBuff, stdErrBuff *bytes.Buffer) (string, string, error) {
+	cmd, err := oc.start(stdOutBuff, stdErrBuff)
+	if err != nil {
+		return "", "", err
+	}
+	err = cmd.Wait()
+
+	stdOutBytes := stdOutBuff.Bytes()
+	stdErrBytes := stdErrBuff.Bytes()
+	stdOut := strings.TrimSpace(string(stdOutBytes))
+	stdErr := strings.TrimSpace(string(stdErrBytes))
+
+	switch err.(type) {
+	case nil:
+		oc.stdout = bytes.NewBuffer(stdOutBytes)
+		oc.stderr = bytes.NewBuffer(stdErrBytes)
+		return stdOut, stdErr, nil
+	case *exec.ExitError:
+		klog.Infof("Error running %v:\nStdOut>\n%s\nStdErr>\n%s\n", cmd, stdOut, stdErr)
+		return stdOut, stdErr, err
+	default:
+		panic(fmt.Errorf("unable to execute %q: %v", oc.execPath, err))
+	}
+}
+
+func (oc *CLI) start(stdOutBuff, stdErrBuff *bytes.Buffer) (*exec.Cmd, error) {
+	oc.finalArgs = append(oc.globalArgs, oc.commandArgs...)
+	if oc.verbose {
+		klog.Infof("DEBUG: oc %s\n", oc.printCmd())
+	}
+	cmd := exec.Command(oc.execPath, oc.finalArgs...)
+	cmd.Stdin = oc.stdin
+
+	cmd.Stdout = stdOutBuff
+	cmd.Stderr = stdErrBuff
+	err := cmd.Start()
+
+	return cmd, err
+}
+
+func (oc *CLI) printCmd() string {
+	return strings.Join(oc.finalArgs, " ")
+}
+
+// OutputToFile executes the command and store output to a file
+func (oc *CLI) OutputToFile(filename string) (string, error) {
+	content, _, err := oc.Outputs()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(oc.outputBasePath, oc.subPath)
+	filePath := filepath.Join(path, oc.Namespace()+"-"+filename)
+
+	if len(content) == 0 {
+		return "", nil
+	}
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return "", fmt.Errorf("err create output directory %s: %w", path, err)
+	}
+	return path, os.WriteFile(filePath, []byte(content), 0644)
+}
+
+// Output executes the command and returns stdout/stderr combined into one string
+func (oc *CLI) Output() (string, error) {
+	var buff bytes.Buffer
+	_, _, err := oc.outputs(&buff, &buff)
+	return strings.TrimSpace(string(buff.Bytes())), err
+}
+
+// Outputs executes the command and returns the stdout/stderr output as separate strings
+func (oc *CLI) Outputs() (string, string, error) {
+	var stdOutBuff, stdErrBuff bytes.Buffer
+	return oc.outputs(&stdOutBuff, &stdErrBuff)
+}
+
+// Namespace returns the name of the namespace used in the current test case.
+// If the namespace is not set, an empty string is returned.
+func (oc *CLI) Namespace() string {
+	return oc.namespace
+}
+
+// WithNamespace sets a new namespace
+func (oc CLI) WithNamespace(ns string) *CLI {
+	oc.namespace = ns
+	return &oc
+}
+
+// WithoutNamespace instructs the command should be invoked without adding --namespace parameter
+func (oc CLI) WithoutNamespace() *CLI {
+	oc.withoutNamespace = true
+	return &oc
+}
+
+// WithSubPath sets a sub path for files with CLI output
+func (oc CLI) WithSubPath(subPath string) *CLI {
+	oc.subPath = subPath
+	return &oc
+}
+
+// WithExec overrides 'oc' executable path
+func (oc CLI) WithExec(execPath string) *CLI {
+	oc.execPath = execPath
+	return &oc
+}
+
+// Run executes given OpenShift CLI command verb (iow. "oc <verb>").
+// This function also override the default 'stdout' to redirect all output
+// to a buffer and prepare the global flags such as namespace and config path.
+func (oc *CLI) Run(commands ...string) *CLI {
+	in, out, errout := &bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}
+	nc := &CLI{
+		execPath:       oc.execPath,
+		verb:           commands[0],
+		configPath:     oc.configPath,
+		outputBasePath: oc.outputBasePath,
+		subPath:        oc.subPath,
+		namespace:      oc.Namespace(),
+		globalArgs:     commands,
+	}
+	if len(oc.configPath) > 0 {
+		nc.globalArgs = append([]string{fmt.Sprintf("--kubeconfig=%s", oc.configPath)}, nc.globalArgs...)
+	}
+	if len(oc.configPath) == 0 && len(oc.token) > 0 {
+		nc.globalArgs = append([]string{fmt.Sprintf("--token=%s", oc.token)}, nc.globalArgs...)
+	}
+	if !oc.withoutNamespace {
+		nc.globalArgs = append([]string{fmt.Sprintf("--namespace=%s", oc.Namespace())}, nc.globalArgs...)
+	}
+	nc.stdin, nc.stdout, nc.stderr = in, out, errout
+	return nc.setOutput(oc.stdout)
+}
+
+// Args sets the additional arguments for the OpenShift CLI command
+func (oc *CLI) Args(args ...string) *CLI {
+	oc.commandArgs = args
+	return oc
+}
+
+// DumpPodLogs will dump any pod logs within namespace
+func (oc *CLI) DumpPodLogs(pods *corev1.PodList, extraLogArgs ...string) {
+	for _, pod := range pods.Items {
+		dumpContainer := func(container *corev1.Container) {
+			logArgs := []string{"pod/" + pod.Name, "-c", container.Name, "-n", pod.Namespace}
+			logArgs = append(logArgs, extraLogArgs...)
+			logFilePath, err := oc.Run("logs").WithoutNamespace().Args(logArgs...).OutputToFile(pod.Name + "_" + container.Name)
+			if err == nil {
+				if logFilePath == "" {
+					klog.Infof("No logs found for pod %s/%s, skipping", pod.Name, container.Name)
+				}
+			} else {
+				klog.Errorf("Error retrieving logs for pod %q/%q: %v\n\n", pod.Name, container.Name, err)
+			}
+		}
+
+		for _, c := range pod.Spec.InitContainers {
+			dumpContainer(&c)
+		}
+		for _, c := range pod.Spec.Containers {
+			dumpContainer(&c)
+		}
+	}
+}
+
+// DumpPodLogsSinceTime will dump any pod logs within namespace from the time provided
+func (oc *CLI) DumpPodLogsSinceTime(ctx context.Context, sinceTime time.Time) {
+	pods := &corev1.PodList{}
+	err := oc.runtimeClient.List(ctx, pods, &runtimeclient.ListOptions{Namespace: oc.Namespace()})
+	if err != nil {
+		klog.Errorf("Error listing pods: %v", err)
+		return
+	}
+	if len(pods.Items) > 0 {
+		oc.DumpPodLogs(pods, "--since-time="+sinceTime.Format(time.RFC3339))
+	}
+}


### PR DESCRIPTION
This adds a gatherer helper for dumping resources and pod logs for failed tests.

This PR contains:

- tiny wrapper around `oc` CLI, which allows to leverage oc binary for retrieving resources and pod logs
- `StateGatherer` helper, which provides shortcuts for dump MAPI related resources and pod logs
- enables gathering for failed tests across the suite
- (also, .ci-operator.yaml was added, just by the way )

Notes:
* This thing relies on `oc` presence within PATH. In CI this requires `oc` to be injected https://docs.ci.openshift.org/docs/architecture/step-registry/#injecting-the-oc-cli