### PR TITLE
Replace busybox image from dockerhub with ubi-minimal from RH registry

### DIFF
--- a/pkg/framework/jobs.go
+++ b/pkg/framework/jobs.go
@@ -22,7 +22,7 @@ func NewWorkLoad(njobs int32, memoryRequest resource.Quantity, workloadJobName s
 					Containers: []corev1.Container{
 						{
 							Name:  workloadJobName,
-							Image: "busybox",
+							Image: "registry.access.redhat.com/ubi8/ubi-minimal:latest",
 							Command: []string{
 								"sleep",
 								"86400", // 1 day


### PR DESCRIPTION
There are rate limits for dockerhub, which causes tests to fail.

https://github.com/openshift/machine-api-operator/pull/1082 - vsphere-operator job here, for example