### PR TITLE
[OCPCLOUD-1732] Add test-e2e-periodic target in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ all: check
 vendor:
 	$(DOCKER_CMD) ./hack/go-mod.sh
 
-
 .PHONY: check
 check: fmt vet #lint ## Check your code
 
@@ -73,6 +72,10 @@ build-e2e:
 .PHONY: test-e2e
 test-e2e: ## Run openshift specific e2e test
 	hack/ci-integration.sh $(GINKGO_ARGS) --label-filter='!(periodic || spot-instances)' -p
+
+.PHONY: test-e2e-periodic
+test-e2e-periodic: ## Run openshift specific periodic e2e test
+	hack/ci-integration.sh $(GINKGO_ARGS) --label-filter=periodic -p
 
 .PHONY: help
 help:

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -238,13 +238,6 @@ var _ = Describe(
 		})
 
 		It("create machines when configured behind a proxy", func() {
-			// This test case takes upwards of 20 minutes to complete.
-			// This test cannot be run in parallel with other tests and as such,
-			// this test has a very high cost associated with it.
-			// The pass rate of this test is normally very good, so we can skip
-			// for now until we are able to move this into a periodic job.
-			Skip("This test is disruptive, slow and expensive. It should only be run periodically and not on presubmits. Skipping until we set up periodics")
-
 			client, err := framework.LoadClient()
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
This PR adds a target to run e2e periodic tests only.