### PR TITLE
OCPCLOUD-1732: Mark some tests as periodics

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -162,7 +162,7 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 		}
 	})
 
-	Context("use a ClusterAutoscaler that has 100 maximum total nodes count", func() {
+	Context("use a ClusterAutoscaler that has 100 maximum total nodes count", framework.LabelPeriodic, func() {
 		var clusterAutoscaler *caov1.ClusterAutoscaler
 		var caEventWatcher *eventWatcher
 
@@ -476,7 +476,7 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 		})
 	})
 
-	Context("use a ClusterAutoscaler that has 8 maximum total nodes", func() {
+	Context("use a ClusterAutoscaler that has 8 maximum total nodes", framework.LabelPeriodic, func() {
 		var clusterAutoscaler *caov1.ClusterAutoscaler
 		caMaxNodesTotal := 8
 

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -283,7 +283,7 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 
 		// Machines required for test: 4
 		// Reason: MachineSet scales 2->0 and MachineSet2 scales 0->2. Changing to scaling 1->0 and 0->1 might not test this thoroughly.
-		It("grow and decrease when scaling different machineSets simultaneously", func() {
+		It("grow and decrease when scaling different machineSets simultaneously", framework.LabelPeriodic, func() {
 			By("Creating a second MachineSet") // Machineset 1 can start with 1 replica
 			machineSetParams := framework.BuildMachineSetParams(client, 0)
 			machineSet2, err := framework.CreateMachineSet(client, machineSetParams)


### PR DESCRIPTION
This commit moves some long-running heavy non-essential tests to periodics, so we won't run them in presubmits to save time and resources.