### PR TITLE
OCPCLOUD-1743 Reduce amount of machines creation

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -214,6 +214,8 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 			}, framework.WaitMedium, pollingInterval).Should(BeTrue())
 		})
 
+		// Machines required for test: 2
+		// Reason: This tests checks that autoscaler is able to scale from zero. It requires 2 machines to ensure it scales to the correct number of nodes based on the workload size.
 		It("It scales from/to zero", func() {
 			// Only run in platforms which support autoscaling from/to zero.
 			clusterInfra, err := framework.GetInfrastructure(client)
@@ -238,7 +240,7 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 
 			framework.WaitForMachineSet(client, machineSet.GetName())
 
-			expectedReplicas := int32(3)
+			expectedReplicas := int32(2)
 			By(fmt.Sprintf("Creating a MachineAutoscaler backed by MachineSet %s/%s - min:%v, max:%v",
 				machineSet.GetNamespace(), machineSet.GetName(), 0, expectedReplicas))
 			asr := machineAutoscalerResource(machineSet, 0, expectedReplicas)
@@ -279,33 +281,28 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 			}, framework.WaitLong, pollingInterval).Should(BeTrue())
 		})
 
+		// Machines required for test: 2
+		// Reason: Needs to scale down to minReplicas = 1. Scales 1 -> 2 -> 1.
 		It("cleanup deletion information after scale down [Slow]", func() {
-			By("Creating 2 MachineSets each with 1 replica")
-			var transientMachineSets [2]*machinev1.MachineSet
+			By("Creating MachineSet with 1 replica")
 			targetedNodeLabel := fmt.Sprintf("%v-delete-cleanup", autoscalerWorkerNodeRoleLabel)
-			for i, machineSet := range transientMachineSets {
-				machineSetParams := framework.BuildMachineSetParams(client, 1)
-				machineSetParams.Labels[targetedNodeLabel] = ""
-				machineSet, err = framework.CreateMachineSet(client, machineSetParams)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupObjects[machineSet.GetName()] = machineSet
-				transientMachineSets[i] = machineSet
-			}
+			machineSetParams := framework.BuildMachineSetParams(client, 1)
+			machineSetParams.Labels[targetedNodeLabel] = ""
+			machineSet, err := framework.CreateMachineSet(client, machineSetParams)
+			Expect(err).ToNot(HaveOccurred())
+			cleanupObjects[machineSet.GetName()] = machineSet
 
-			By("Waiting for all Machines in MachineSets to enter Running phase")
-			framework.WaitForMachineSet(client, transientMachineSets[0].GetName())
-			framework.WaitForMachineSet(client, transientMachineSets[1].GetName())
+			By("Waiting for the machineSet to enter Running phase")
+			framework.WaitForMachineSet(client, machineSet.GetName())
 
-			expectedReplicas := int32(3)
-			for _, machineSet := range transientMachineSets {
-				By(fmt.Sprintf("Creating a MachineAutoscaler backed by MachineSet %s - min: 1, max: %d",
-					machineSet.GetName(), expectedReplicas))
-				asr := machineAutoscalerResource(machineSet, 1, expectedReplicas)
-				Expect(client.Create(ctx, asr)).Should(Succeed())
-				cleanupObjects[asr.GetName()] = asr
-			}
+			expectedReplicas := int32(2)
+			By(fmt.Sprintf("Creating a MachineAutoscaler backed by MachineSet %s - min: 1, max: %d",
+				machineSet.GetName(), expectedReplicas))
+			asr := machineAutoscalerResource(machineSet, 1, expectedReplicas)
+			Expect(client.Create(ctx, asr)).Should(Succeed())
+			cleanupObjects[asr.GetName()] = asr
 
-			jobReplicas := expectedReplicas * int32(2)
+			jobReplicas := expectedReplicas
 			uniqueJobName := fmt.Sprintf("%s-cleanup-after-scale-down", workloadJobName)
 			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
 				uniqueJobName, jobReplicas, workloadMemRequest.String()))
@@ -313,103 +310,80 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 			cleanupObjects[workload.GetName()] = workload
 			Expect(client.Create(ctx, workload)).Should(Succeed())
 
-			for _, machineSet := range transientMachineSets {
-				By(fmt.Sprintf("Waiting for MachineSet %s replicas to scale out", machineSet.GetName()))
-			}
-			Eventually(func() (bool, error) {
-				for _, machineSet := range transientMachineSets {
-					current, err := framework.GetMachineSet(client, machineSet.GetName())
-					if err != nil {
-						return false, err
-					}
-					if *current.Spec.Replicas != expectedReplicas {
-						return false, nil
-					}
+			By(fmt.Sprintf("Waiting for MachineSet %s replicas to scale out", machineSet.GetName()))
+			Eventually(func() (int32, error) {
+				current, err := framework.GetMachineSet(client, machineSet.GetName())
+				if err != nil {
+					return 0, err
 				}
-				return true, nil
-			}, framework.WaitMedium, pollingInterval).Should(BeTrue())
+				return *current.Spec.Replicas, nil
+			}, framework.WaitMedium, pollingInterval).Should(BeEquivalentTo(expectedReplicas))
 
-			By("Waiting for all Machines in MachineSets to enter Running phase")
-			framework.WaitForMachineSet(client, transientMachineSets[0].GetName())
-			framework.WaitForMachineSet(client, transientMachineSets[1].GetName())
+			By("Waiting for all Machines in the MachineSet to enter Running phase")
+			framework.WaitForMachineSet(client, machineSet.GetName())
 
 			By("Deleting the workload")
 			Expect(deleteObject(workload.Name, cleanupObjects[workload.Name])).Should(Succeed())
 			delete(cleanupObjects, workload.Name)
 
-			for _, machineSet := range transientMachineSets {
-				By(fmt.Sprintf("Waiting for MachineSet %s replicas to scale in", machineSet.GetName()))
-			}
+			By(fmt.Sprintf("Waiting for MachineSet %s replicas to scale in", machineSet.GetName()))
 			expectedLength := 1
-			Eventually(func() (bool, error) {
-				for _, machineSet := range transientMachineSets {
-					machines, err := framework.GetMachinesFromMachineSet(client, machineSet)
+			var machines []*machinev1.Machine
+			Eventually(func() (int, error) {
+				machines, err = framework.GetMachinesFromMachineSet(client, machineSet)
+				if err != nil {
+					return 0, err
+				}
+				return len(machines), nil
+			}, framework.WaitLong, pollingInterval).Should(BeEquivalentTo(expectedLength))
+
+			for _, machine := range machines {
+				By(fmt.Sprintf("Checking Machine %s for %s annotation", machine.Name, machineDeleteAnnotationKey))
+				Eventually(func() (bool, error) {
+					m, err := framework.GetMachine(client, machine.Name)
 					if err != nil {
 						return false, err
 					}
-					if len(machines) != expectedLength {
+					if m.ObjectMeta.Annotations == nil {
+						return true, nil
+					}
+					if _, exists := m.ObjectMeta.Annotations[machineDeleteAnnotationKey]; exists {
 						return false, nil
 					}
-				}
-				return true, nil
-			}, framework.WaitLong, pollingInterval).Should(BeTrue())
-
-			for _, machineSet := range transientMachineSets {
-				machines, err := framework.GetMachinesFromMachineSet(client, machineSet)
-				Expect(err).NotTo(HaveOccurred())
-				for _, machine := range machines {
-					By(fmt.Sprintf("Checking Machine %s for %s annotation", machine.Name, machineDeleteAnnotationKey))
-					Eventually(func() (bool, error) {
-						m, err := framework.GetMachine(client, machine.Name)
-						if err != nil {
-							return false, err
-						}
-						if m.ObjectMeta.Annotations == nil {
-							return true, nil
-						}
-						if _, exists := m.ObjectMeta.Annotations[machineDeleteAnnotationKey]; exists {
-							return false, nil
-						}
-						return true, nil
-					}, framework.WaitMedium, pollingInterval).Should(BeTrue())
-				}
+					return true, nil
+				}, framework.WaitMedium, pollingInterval).Should(BeTrue())
 			}
 
-			for _, machineSet := range transientMachineSets {
-				machines, err := framework.GetMachinesFromMachineSet(client, machineSet)
-				Expect(err).NotTo(HaveOccurred())
-				for _, machine := range machines {
-					if machine.Status.NodeRef == nil {
-						continue
-					}
-					By(fmt.Sprintf("Checking Node %s for %s and %s taints", machine.Status.NodeRef.Name, deletionCandidateTaintKey, toBeDeletedTaintKey))
-					Eventually(func() (bool, error) {
-						n, err := framework.GetNodeForMachine(client, machine)
-						if err != nil {
-							return false, err
-						}
-						for _, t := range n.Spec.Taints {
-							if t.Key == deletionCandidateTaintKey || t.Key == toBeDeletedTaintKey {
-								return false, nil
-							}
-						}
-						return true, nil
-					}, framework.WaitMedium, pollingInterval).Should(BeTrue())
+			for _, machine := range machines {
+				if machine.Status.NodeRef == nil {
+					continue
 				}
+				By(fmt.Sprintf("Checking Node %s for %s and %s taints", machine.Status.NodeRef.Name, deletionCandidateTaintKey, toBeDeletedTaintKey))
+				Eventually(func() (bool, error) {
+					n, err := framework.GetNodeForMachine(client, machine)
+					if err != nil {
+						return false, err
+					}
+					for _, t := range n.Spec.Taints {
+						if t.Key == deletionCandidateTaintKey || t.Key == toBeDeletedTaintKey {
+							return false, nil
+						}
+					}
+					return true, nil
+				}, framework.WaitMedium, pollingInterval).Should(BeTrue())
 			}
 		})
 	})
 
-	Context("use a ClusterAutoscaler that has 12 maximum total nodes count and balance similar nodes enabled", func() {
+	Context("use a ClusterAutoscaler that has balance similar nodes enabled and 100 maximum total nodes", func() {
 		var clusterAutoscaler *caov1.ClusterAutoscaler
-		const caMaxNodesTotal = 12
 
 		BeforeEach(func() {
 			gatherer, err = framework.NewGatherer()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Creating ClusterAutoscaler")
-			clusterAutoscaler = clusterAutoscalerResource(caMaxNodesTotal)
+			clusterAutoscaler = clusterAutoscalerResource(100)
 			clusterAutoscaler.Spec.BalanceSimilarNodeGroups = pointer.BoolPtr(true)
 			Expect(client.Create(ctx, clusterAutoscaler)).Should(Succeed())
 			cleanupObjects[clusterAutoscaler.GetName()] = clusterAutoscaler
@@ -417,7 +391,7 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 
 		AfterEach(func() {
 			specReport := CurrentSpecReport()
-			if specReport.Failed() == true {
+			if specReport.Failed() {
 				Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed())
 			}
 
@@ -438,7 +412,122 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 			}, framework.WaitMedium, pollingInterval).Should(BeTrue())
 		})
 
+		// Machines required for test: 4
+		// Reason: This test starts with 2 machinesets, each with 1 replica to avoid scaling from zero.
+		// Then it autoscales both machinesets to 2 replicas.
+		// Does not start with replicas=0 machineset to avoid scaling from 0.
+		It("places nodes evenly across node groups [Slow]", func() {
+			By("Creating 2 MachineSets each with 1 replica")
+			var transientMachineSets [2]*machinev1.MachineSet
+			targetedNodeLabel := fmt.Sprintf("%v-balance-nodes", autoscalerWorkerNodeRoleLabel)
+			for i, machineSet := range transientMachineSets {
+				machineSetParams := framework.BuildMachineSetParams(client, 1)
+				machineSetParams.Labels[targetedNodeLabel] = ""
+				// remove this label to make the MachineSets similar, see below for more details
+				delete(machineSetParams.Labels, "e2e.openshift.io")
+				machineSet, err = framework.CreateMachineSet(client, machineSetParams)
+				Expect(err).ToNot(HaveOccurred())
+				cleanupObjects[machineSet.GetName()] = machineSet
+				transientMachineSets[i] = machineSet
+			}
+
+			// balance similar nodes requires that all the participating MachineSets have the same
+			// instance types and labels. while the instance types should be the same, we want to
+			// ensure that no extra labels have been added.
+			// TODO it would be nice to check instance types as well, this will require adding some deserialization code for the machine specs.
+			By("Ensuring both MachineSets have the same labels")
+			Expect(reflect.DeepEqual(transientMachineSets[0].Labels, transientMachineSets[1].Labels)).Should(BeTrue())
+
+			By("Waiting for all Machines in MachineSets to enter Running phase")
+			framework.WaitForMachineSet(client, transientMachineSets[0].GetName())
+			framework.WaitForMachineSet(client, transientMachineSets[1].GetName())
+
+			maxMachineSetReplicas := int32(3)
+			for _, machineSet := range transientMachineSets {
+				By(fmt.Sprintf("Creating a MachineAutoscaler backed by MachineSet %s - min: 1, max: %d",
+					machineSet.GetName(), maxMachineSetReplicas))
+				asr := machineAutoscalerResource(machineSet, 1, maxMachineSetReplicas)
+				Expect(client.Create(ctx, asr)).Should(Succeed())
+				cleanupObjects[asr.GetName()] = asr
+			}
+
+			// 4 job replicas are being chosen here to force the cluster to
+			// expand its size by 2 nodes. the cluster autoscaler should
+			// place 1 node in each of the 2 MachineSets created.
+			jobReplicas := int32(4)
+			uniqueJobName := fmt.Sprintf("%s-balance-nodegroups", workloadJobName)
+			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
+				uniqueJobName, jobReplicas, workloadMemRequest.String()))
+			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
+			cleanupObjects[workload.GetName()] = workload
+			Expect(client.Create(ctx, workload)).Should(Succeed())
+
+			expectedReplicas := int32(2)
+			for _, machineSet := range transientMachineSets {
+				By(fmt.Sprintf("Waiting for MachineSet %s replicas to scale out", machineSet.GetName()))
+				Eventually(func() (int, error) {
+					current, err := framework.GetMachineSet(client, machineSet.GetName())
+					if err != nil {
+						return 0, err
+					}
+					return int(pointer.Int32Deref(current.Spec.Replicas, 0)), nil
+				}, framework.WaitOverMedium, pollingInterval).Should(BeEquivalentTo(expectedReplicas))
+			}
+		})
+	})
+
+	Context("use a ClusterAutoscaler that has 8 maximum total nodes", func() {
+		var clusterAutoscaler *caov1.ClusterAutoscaler
+		caMaxNodesTotal := 8
+
+		BeforeEach(func() {
+			gatherer, err = framework.NewGatherer()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating ClusterAutoscaler")
+			clusterAutoscaler = clusterAutoscalerResource(caMaxNodesTotal)
+			Expect(client.Create(ctx, clusterAutoscaler)).Should(Succeed())
+			cleanupObjects[clusterAutoscaler.GetName()] = clusterAutoscaler
+		})
+
+		AfterEach(func() {
+			specReport := CurrentSpecReport()
+			if specReport.Failed() {
+				Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed())
+			}
+
+			// explicitly delete the ClusterAutoscaler
+			// this is needed due to the autoscaler tests requiring singleton
+			// deployments of the ClusterAutoscaler.
+			By("Waiting for ClusterAutoscaler to delete.")
+			caName := clusterAutoscaler.GetName()
+			Expect(deleteObject(caName, cleanupObjects[caName])).Should(Succeed())
+			delete(cleanupObjects, caName)
+			Eventually(func() (bool, error) {
+				_, err := framework.GetClusterAutoscaler(client, caName)
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				// Return the error so that failures print additional errors
+				return false, err
+			}, framework.WaitMedium, pollingInterval).Should(BeTrue())
+		})
+
+		// Machines required for test: 2
+		// Reason: This test starts with 1 replica machineSet. Then it creates a workload that would require 3 replicas,
+		// but it only scales up to 2 replicas because the cluster is at maximum size of 8 machines. (3 masters and 3 other worker machines; 2 workers from this test)
+		// Does not start with replicas=0 machineset to avoid scaling from 0.
 		It("scales up and down while respecting MaxNodesTotal [Slow][Serial]", func() {
+			// This test requires to have exactly 6 machines in the cluster at the begining and to run serially.
+			By("Ensuring there are 6 machines in the cluster")
+			Eventually(func() (int, error) {
+				machines, err := framework.GetMachines(client)
+				if err != nil {
+					return 0, err
+				}
+				return len(machines), nil
+			}, framework.WaitLong, pollingInterval).Should(BeEquivalentTo(6), "Expected to have 6 machines in the cluster")
+
 			By("Creating 1 MachineSet with 1 replica")
 			var transientMachineSet *machinev1.MachineSet
 			targetedNodeLabel := fmt.Sprintf("%v-scale-updown", autoscalerWorkerNodeRoleLabel)
@@ -527,68 +616,6 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 				machines, err := framework.GetMachinesFromMachineSet(client, transientMachineSet)
 				return len(machines) == 1, err
 			}, framework.WaitLong, pollingInterval).Should(BeTrue())
-		})
-
-		It("places nodes evenly across node groups [Slow]", func() {
-			By("Creating 2 MachineSets each with 1 replica")
-			var transientMachineSets [2]*machinev1.MachineSet
-			targetedNodeLabel := fmt.Sprintf("%v-balance-nodes", autoscalerWorkerNodeRoleLabel)
-			for i, machineSet := range transientMachineSets {
-				machineSetParams := framework.BuildMachineSetParams(client, 1)
-				machineSetParams.Labels[targetedNodeLabel] = ""
-				// remove this label to make the MachineSets similar, see below for more details
-				delete(machineSetParams.Labels, "e2e.openshift.io")
-				machineSet, err = framework.CreateMachineSet(client, machineSetParams)
-				Expect(err).ToNot(HaveOccurred())
-				cleanupObjects[machineSet.GetName()] = machineSet
-				transientMachineSets[i] = machineSet
-			}
-
-			// balance similar nodes requires that all the participating MachineSets have the same
-			// instance types and labels. while the instance types should be the same, we want to
-			// ensure that no extra labels have been added.
-			// TODO it would be nice to check instance types as well, this will require adding some deserialization code for the machine specs.
-			By("Ensuring both MachineSets have the same labels")
-			Expect(reflect.DeepEqual(transientMachineSets[0].Labels, transientMachineSets[1].Labels)).Should(BeTrue())
-
-			By("Waiting for all Machines in MachineSets to enter Running phase")
-			framework.WaitForMachineSet(client, transientMachineSets[0].GetName())
-			framework.WaitForMachineSet(client, transientMachineSets[1].GetName())
-
-			maxMachineSetReplicas := int32(3)
-			for _, machineSet := range transientMachineSets {
-				By(fmt.Sprintf("Creating a MachineAutoscaler backed by MachineSet %s - min: 1, max: %d",
-					machineSet.GetName(), maxMachineSetReplicas))
-				asr := machineAutoscalerResource(machineSet, 1, maxMachineSetReplicas)
-				Expect(client.Create(ctx, asr)).Should(Succeed())
-				cleanupObjects[asr.GetName()] = asr
-			}
-
-			// 4 job replicas are being chosen here to force the cluster to
-			// expand its size by 2 nodes. the cluster autoscaler should
-			// place 1 node in each of the 2 MachineSets created.
-			jobReplicas := int32(4)
-			uniqueJobName := fmt.Sprintf("%s-balance-nodegroups", workloadJobName)
-			By(fmt.Sprintf("Creating scale-out workload %s: jobs: %v, memory: %s",
-				uniqueJobName, jobReplicas, workloadMemRequest.String()))
-			workload := framework.NewWorkLoad(jobReplicas, workloadMemRequest, uniqueJobName, autoscalingTestLabel, targetedNodeLabel, "")
-			cleanupObjects[workload.GetName()] = workload
-			Expect(client.Create(ctx, workload)).Should(Succeed())
-
-			expectedReplicas := int32(2)
-			for _, machineSet := range transientMachineSets {
-				By(fmt.Sprintf("Waiting for MachineSet %s replicas to scale out", machineSet.GetName()))
-				Eventually(func() (bool, error) {
-					current, err := framework.GetMachineSet(client, machineSet.GetName())
-					if err != nil {
-						return false, err
-					}
-					if pointer.Int32Deref(current.Spec.Replicas, 0) != expectedReplicas {
-						return false, nil
-					}
-					return true, nil
-				}, framework.WaitOverMedium, pollingInterval).Should(BeTrue())
-			}
 		})
 	})
 })

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -11,6 +11,7 @@ import (
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -156,13 +157,6 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 		client, err = framework.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
 
-		machineSetParams = framework.BuildMachineSetParams(client, 2)
-
-		By("Creating a new MachineSet")
-		machineSet, err = framework.CreateMachineSet(client, machineSetParams)
-		Expect(err).ToNot(HaveOccurred())
-
-		framework.WaitForMachineSet(client, machineSet.GetName())
 	})
 
 	AfterEach(func() {
@@ -171,175 +165,224 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 			Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed())
 		}
 
-		By("Deleting the new MachineSet")
-		err := client.Delete(context.Background(), machineSet)
-		Expect(err).ToNot(HaveOccurred())
+		if machineSet != nil {
+			By("Deleting the new MachineSet")
+			err := client.Delete(context.Background(), machineSet)
+			Expect(err).ToNot(HaveOccurred())
+			framework.WaitForMachineSetDelete(client, machineSet)
+		}
 
-		framework.WaitForMachineSetDelete(client, machineSet)
 	})
 
-	It("have ability to additively reconcile taints from machine to nodes", func() {
-		selector := machineSet.Spec.Selector
-		machines, err := framework.GetMachines(client, &selector)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(machines).ToNot(BeEmpty())
+	When("machineset has one replica", func() {
+		BeforeEach(func() {
+			var err error
+			machineSetParams = framework.BuildMachineSetParams(client, 1)
 
-		machine := machines[0]
-		By(fmt.Sprintf("getting machine %q", machine.Name))
+			By("Creating a new MachineSet")
+			machineSet, err = framework.CreateMachineSet(client, machineSetParams)
+			Expect(err).ToNot(HaveOccurred())
 
-		node, err := framework.GetNodeForMachine(client, machine)
-		Expect(err).NotTo(HaveOccurred())
-		By(fmt.Sprintf("getting the backed node %q", node.Name))
+			framework.WaitForMachineSet(client, machineSet.GetName())
+		})
 
-		nodeTaint := corev1.Taint{
-			Key:    "not-from-machine",
-			Value:  "true",
-			Effect: corev1.TaintEffectNoSchedule,
-		}
-		By(fmt.Sprintf("updating node %q with taint: %v", node.Name, nodeTaint))
-		node.Spec.Taints = append(node.Spec.Taints, nodeTaint)
-		err = client.Update(context.TODO(), node)
-		Expect(err).NotTo(HaveOccurred())
+		// Machines required for test: 1
+		// Reason: This test works on a single machine and its node.
+		It("have ability to additively reconcile taints from machine to nodes", func() {
+			selector := machineSet.Spec.Selector
+			machines, err := framework.GetMachines(client, &selector)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(machines).ToNot(BeEmpty())
 
-		machineTaint := corev1.Taint{
-			Key:    fmt.Sprintf("from-machine-%v", string(uuid.NewUUID())),
-			Value:  "true",
-			Effect: corev1.TaintEffectNoSchedule,
-		}
-		By(fmt.Sprintf("updating machine %q with taint: %v", machine.Name, machineTaint))
-		machine.Spec.Taints = append(machine.Spec.Taints, machineTaint)
-		err = client.Update(context.TODO(), machine)
-		Expect(err).NotTo(HaveOccurred())
+			machine := machines[0]
+			By(fmt.Sprintf("getting machine %q", machine.Name))
 
-		var expectedTaints = sets.NewString("not-from-machine", machineTaint.Key)
-		Eventually(func() bool {
-			klog.Info("Getting node from machine again for verification of taints")
 			node, err := framework.GetNodeForMachine(client, machine)
-			if err != nil {
+			Expect(err).NotTo(HaveOccurred())
+			By(fmt.Sprintf("getting the backed node %q", node.Name))
+
+			nodeTaint := corev1.Taint{
+				Key:    "not-from-machine",
+				Value:  "true",
+				Effect: corev1.TaintEffectNoSchedule,
+			}
+			By(fmt.Sprintf("updating node %q with taint: %v", node.Name, nodeTaint))
+			for {
+				node.Spec.Taints = append(node.Spec.Taints, nodeTaint)
+				err = client.Update(context.TODO(), node)
+				if !apierrors.IsConflict(err) {
+					break
+				}
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			machineTaint := corev1.Taint{
+				Key:    fmt.Sprintf("from-machine-%v", string(uuid.NewUUID())),
+				Value:  "true",
+				Effect: corev1.TaintEffectNoSchedule,
+			}
+			By(fmt.Sprintf("updating machine %q with taint: %v", machine.Name, machineTaint))
+			for {
+				machine.Spec.Taints = append(machine.Spec.Taints, machineTaint)
+				err = client.Update(context.TODO(), machine)
+				if !apierrors.IsConflict(err) {
+					break
+				}
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			var expectedTaints = sets.NewString("not-from-machine", machineTaint.Key)
+			Eventually(func() bool {
+				klog.Info("Getting node from machine again for verification of taints")
+				node, err := framework.GetNodeForMachine(client, machine)
+				if err != nil {
+					return false
+				}
+				var observedTaints = sets.NewString()
+				for _, taint := range node.Spec.Taints {
+					observedTaints.Insert(taint.Key)
+				}
+				if expectedTaints.Difference(observedTaints).HasAny("not-from-machine", machineTaint.Key) == false {
+					klog.Infof("Expected : %v, observed %v , difference %v, ", expectedTaints, observedTaints, expectedTaints.Difference(observedTaints))
+					return true
+				}
+				klog.Infof("Did not find all expected taints on the node. Missing: %v", expectedTaints.Difference(observedTaints))
 				return false
-			}
-			var observedTaints = sets.NewString()
-			for _, taint := range node.Spec.Taints {
-				observedTaints.Insert(taint.Key)
-			}
-			if expectedTaints.Difference(observedTaints).HasAny("not-from-machine", machineTaint.Key) == false {
-				klog.Infof("Expected : %v, observed %v , difference %v, ", expectedTaints, observedTaints, expectedTaints.Difference(observedTaints))
-				return true
-			}
-			klog.Infof("Did not find all expected taints on the node. Missing: %v", expectedTaints.Difference(observedTaints))
-			return false
-		}, framework.WaitMedium, 5*time.Second).Should(BeTrue())
+			}, framework.WaitMedium, 5*time.Second).Should(BeTrue())
+		})
+
 	})
 
-	It("recover from deleted worker machines", func() {
-		selector := machineSet.Spec.Selector
-		machines, err := framework.GetMachines(client, &selector)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(machines).ToNot(BeEmpty())
+	When("machineset has 2 replicas", func() {
+		BeforeEach(func() {
+			var err error
+			machineSetParams = framework.BuildMachineSetParams(client, 2)
 
-		By(fmt.Sprint("deleting all machines"))
-		err = framework.DeleteMachines(client, machines...)
-		Expect(err).NotTo(HaveOccurred())
-		framework.WaitForMachinesDeleted(client, machines...)
-
-		framework.WaitForMachineSet(client, machineSet.GetName())
-	})
-
-	It("grow and decrease when scaling different machineSets simultaneously", func() {
-		By("Creating a second MachineSet")
-		machineSetParams := framework.BuildMachineSetParams(client, 0)
-		machineSet2, err := framework.CreateMachineSet(client, machineSetParams)
-		Expect(err).ToNot(HaveOccurred())
-
-		// Make sure second machineset gets deleted anyway
-		defer func() {
-			By("Deleting the second MachineSet")
-			err := deleteObject(client, machineSet2)
+			By("Creating a new MachineSet")
+			machineSet, err = framework.CreateMachineSet(client, machineSetParams)
 			Expect(err).ToNot(HaveOccurred())
-			framework.WaitForMachineSetDelete(client, machineSet2)
-		}()
 
-		framework.WaitForMachineSet(client, machineSet2.GetName())
+			framework.WaitForMachineSet(client, machineSet.GetName())
+		})
 
-		Expect(framework.ScaleMachineSet(machineSet.GetName(), 0)).To(Succeed())
-		Expect(framework.ScaleMachineSet(machineSet2.GetName(), 3)).To(Succeed())
-
-		framework.WaitForMachineSet(client, machineSet.GetName())
-		framework.WaitForMachineSet(client, machineSet2.GetName())
-	})
-
-	It("drain node before removing machine resource", func() {
-		By("Create a machine for node about to be drained")
-
-		selector := machineSet.Spec.Selector
-		machines, err := framework.GetMachines(client, &selector)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(machines)).To(BeNumerically(">=", 2))
-
-		// Add node draining labels to params
-		for k, v := range nodeDrainLabels {
-			machineSetParams.Labels[k] = v
-		}
-
-		machines[0].Spec.ObjectMeta.Labels = machineSetParams.Labels
-		machines[1].Spec.ObjectMeta.Labels = machineSetParams.Labels
-
-		err = client.Update(context.TODO(), machines[0])
-		Expect(err).ToNot(HaveOccurred())
-
-		err = client.Update(context.TODO(), machines[1])
-		Expect(err).ToNot(HaveOccurred())
-
-		// Make sure RC and PDB get deleted anyway
-		delObjects := make(map[string]runtimeclient.Object)
-
-		defer func() {
-			err := deleteObjects(client, delObjects)
+		// Machines required for test: 2
+		// Reason: We want to test that all machines get replaced when we delete them.
+		It("recover from deleted worker machines", func() {
+			selector := machineSet.Spec.Selector
+			machines, err := framework.GetMachines(client, &selector)
 			Expect(err).ToNot(HaveOccurred())
-		}()
+			Expect(machines).ToNot(BeEmpty())
 
-		By("Creating RC with workload")
+			By(fmt.Sprint("deleting all machines"))
+			err = framework.DeleteMachines(client, machines...)
+			Expect(err).NotTo(HaveOccurred())
+			framework.WaitForMachinesDeleted(client, machines...)
 
-		// Use the openshift-machine-api namespace as it is excluded from
-		// Pod security admission checks.
-		namespace := framework.MachineAPINamespace
+			framework.WaitForMachineSet(client, machineSet.GetName())
+		})
 
-		rc := replicationControllerWorkload(namespace)
-		err = client.Create(context.TODO(), rc)
-		Expect(err).NotTo(HaveOccurred())
-		delObjects["rc"] = rc
+		// Machines required for test: 4
+		// Reason: MachineSet scales 2->0 and MachineSet2 scales 0->2. Changing to scaling 1->0 and 0->1 might not test this thoroughly.
+		It("grow and decrease when scaling different machineSets simultaneously", func() {
+			By("Creating a second MachineSet") // Machineset 1 can start with 1 replica
+			machineSetParams := framework.BuildMachineSetParams(client, 0)
+			machineSet2, err := framework.CreateMachineSet(client, machineSetParams)
+			Expect(err).ToNot(HaveOccurred())
 
-		By("Creating PDB for RC")
-		pdb := podDisruptionBudget(namespace)
-		err = client.Create(context.TODO(), pdb)
-		Expect(err).NotTo(HaveOccurred())
-		delObjects["pdb"] = pdb
+			// Make sure second machineset gets deleted anyway
+			defer func() {
+				By("Deleting the second MachineSet")
+				err := deleteObject(client, machineSet2)
+				Expect(err).ToNot(HaveOccurred())
+				framework.WaitForMachineSetDelete(client, machineSet2)
+			}()
 
-		By("Wait until all replicas are ready")
-		err = framework.WaitUntilAllRCPodsAreReady(client, rc)
-		Expect(err).NotTo(HaveOccurred())
+			framework.WaitForMachineSet(client, machineSet2.GetName())
 
-		// TODO(jchaloup): delete machine that has at least half of the RC pods
+			Expect(framework.ScaleMachineSet(machineSet.GetName(), 0)).To(Succeed())
+			Expect(framework.ScaleMachineSet(machineSet2.GetName(), 1)).To(Succeed())
 
-		// All pods are distributed evenly among all nodes so it's fine to drain
-		// random node and observe reconciliation of pods on the other one.
-		By("Delete machine to trigger node draining")
-		err = client.Delete(context.TODO(), machines[0])
-		Expect(err).NotTo(HaveOccurred())
+			framework.WaitForMachineSet(client, machineSet.GetName())
+			framework.WaitForMachineSet(client, machineSet2.GetName())
+		})
 
-		// We still should be able to list the machine as until rc.replicas-1 are running on the other node
-		By("Observing and verifying node draining")
-		drainedNodeName, err := framework.VerifyNodeDraining(client, machines[0], rc)
-		Expect(err).NotTo(HaveOccurred())
+		// Machines required for test: 2 (3 but it gets deleted without waiting for it to be ready)
+		// Reason: Pods are spread across both machines. After one is deleted, the pods are rescheduled onto the other machine.
+		It("drain node before removing machine resource", func() {
+			By("Create a machine for node about to be drained")
 
-		By("Validating the machine is deleted")
-		framework.WaitForMachinesDeleted(client, machines[0])
+			selector := machineSet.Spec.Selector
+			machines, err := framework.GetMachines(client, &selector)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(machines)).To(BeNumerically(">=", 2))
 
-		By("Validate underlying node corresponding to machine1 is removed as well")
-		err = framework.WaitUntilNodeDoesNotExists(client, drainedNodeName)
-		Expect(err).NotTo(HaveOccurred())
+			// Add node draining labels to params
+			for k, v := range nodeDrainLabels {
+				machineSetParams.Labels[k] = v
+			}
+
+			machines[0].Spec.ObjectMeta.Labels = machineSetParams.Labels
+			machines[1].Spec.ObjectMeta.Labels = machineSetParams.Labels
+
+			err = client.Update(context.TODO(), machines[0])
+			Expect(err).ToNot(HaveOccurred())
+
+			err = client.Update(context.TODO(), machines[1])
+			Expect(err).ToNot(HaveOccurred())
+
+			// Make sure RC and PDB get deleted anyway
+			delObjects := make(map[string]runtimeclient.Object)
+
+			defer func() {
+				err := deleteObjects(client, delObjects)
+				Expect(err).ToNot(HaveOccurred())
+			}()
+
+			By("Creating RC with workload")
+
+			// Use the openshift-machine-api namespace as it is excluded from
+			// Pod security admission checks.
+			namespace := framework.MachineAPINamespace
+
+			rc := replicationControllerWorkload(namespace)
+			err = client.Create(context.TODO(), rc)
+			Expect(err).NotTo(HaveOccurred())
+			delObjects["rc"] = rc
+
+			By("Creating PDB for RC")
+			pdb := podDisruptionBudget(namespace)
+			err = client.Create(context.TODO(), pdb)
+			Expect(err).NotTo(HaveOccurred())
+			delObjects["pdb"] = pdb
+
+			By("Wait until all replicas are ready")
+			err = framework.WaitUntilAllRCPodsAreReady(client, rc)
+			Expect(err).NotTo(HaveOccurred())
+
+			// TODO(jchaloup): delete machine that has at least half of the RC pods
+
+			// All pods are distributed evenly among all nodes so it's fine to drain
+			// random node and observe reconciliation of pods on the other one.
+			By("Delete machine to trigger node draining")
+			err = client.Delete(context.TODO(), machines[0])
+			Expect(err).NotTo(HaveOccurred())
+
+			// We still should be able to list the machine as until rc.replicas-1 are running on the other node
+			By("Observing and verifying node draining")
+			drainedNodeName, err := framework.VerifyNodeDraining(client, machines[0], rc)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Validating the machine is deleted")
+			framework.WaitForMachinesDeleted(client, machines[0])
+
+			By("Validate underlying node corresponding to machine1 is removed as well")
+			err = framework.WaitUntilNodeDoesNotExists(client, drainedNodeName)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
+	// Machines required for test: 0
+	// Reason: The machineSet creation is rejected by the webhook.
 	It("reject invalid machinesets", func() {
 		By("Creating invalid machineset")
 		invalidMachineSet := invalidMachinesetWithEmptyProviderConfig()

--- a/pkg/infra/lifecyclehooks.go
+++ b/pkg/infra/lifecyclehooks.go
@@ -98,6 +98,8 @@ var _ = Describe("Lifecycle Hooks should", framework.LabelMachines, func() {
 		})).To(Succeed())
 	})
 
+	// Machines required for test: 1
+	// Reason: Tracks the lifecycle of a single machine as we update its lifecycle hooks
 	It("pause lifecycle actions when present", func() {
 		machines, err := framework.GetMachinesFromMachineSet(client, machineSet)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	// Spot machineSet replicas
-	machinesCount = 3
+	machinesCount = 1
 
 	// Maximum retries when provisioning a spot machineSet
 	spotMachineSetMaxProvisioningRetryCount = 3
@@ -132,6 +132,8 @@ var _ = Describe("Running on Spot", framework.LabelMachines, framework.LabelSpot
 		}
 	})
 
+	// Machines required for test: 1
+	// Reason: We only deploy the termination simulator pod on one node. Machine draining is tested in other tests.
 	It("should handle the spot instances", func() {
 		By("should label the Machine specs as interruptible", func() {
 			selector := machineSet.Spec.Selector

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -89,6 +89,8 @@ var _ = Describe("Webhooks", framework.LabelMachines, func() {
 		framework.WaitForMachinesDeleted(client, machines...)
 	})
 
+	// Machines required for test: 1
+	// Reason: It needs to verify that machine with minimal provider spec is able to go into running phase.
 	It("should be able to create a machine from a minimal providerSpec", func() {
 		machine := &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
@@ -115,6 +117,8 @@ var _ = Describe("Webhooks", framework.LabelMachines, func() {
 		}, framework.WaitLong, framework.RetryMedium).Should(Succeed())
 	})
 
+	// Machines required for test: 1
+	// Reason: It needs to verify that machine created from the machineSet with minimal provider spec is able to go into running phase.
 	It("should be able to create machines from a machineset with a minimal providerSpec", func() {
 		machineSet, err := framework.CreateMachineSet(client, machineSetParams)
 		Expect(err).ToNot(HaveOccurred())
@@ -122,6 +126,8 @@ var _ = Describe("Webhooks", framework.LabelMachines, func() {
 		framework.WaitForMachineSet(client, machineSet.Name)
 	})
 
+	// Machines required for test: 1
+	// Reason: We need a machine to test updating its providerSpec. We don't wait for this machine to be running.
 	It("should return an error when removing required fields from the Machine providerSpec", func() {
 		machine := &machinev1beta1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
@@ -156,7 +162,10 @@ var _ = Describe("Webhooks", framework.LabelMachines, func() {
 		}
 	})
 
+	// Machines required for test: 0
+	// Reason: We don't need to start creating the machine, because we are only testing the machineSet webhook.
 	It("should return an error when removing required fields from the MachineSet providerSpec", func() {
+		machineSetParams.Replicas = 0
 		machineSet, err := framework.CreateMachineSet(client, machineSetParams)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -237,6 +237,8 @@ var _ = Describe(
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		// Machines required for test: 1
+		// Reason: Tests that machine creation is possible behind a proxy.
 		It("create machines when configured behind a proxy", func() {
 			client, err := framework.LoadClient()
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/providers/aws.go
+++ b/pkg/providers/aws.go
@@ -121,18 +121,24 @@ var _ = Describe("MetadataServiceOptions", framework.LabelCloudProviderSpecific,
 		})
 	}
 
+	// Machines required for test: 0
+	// No machines are created, because the machineSet is rejected.
 	It("should not allow to create machineset with incorrect metadataServiceOptions.authentication", func() {
 		_, err := createMachineSet("fooobaar")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).Should(ContainSubstring("Invalid value: \"fooobaar\": Allowed values are either 'Optional' or 'Required'"))
 	})
 
+	// Machines required for test: 1
+	// Reason: Deploys a pod on the node, so it requires a machine to be running.
 	It("should enforce auth on metadata service if metadataServiceOptions.authentication set to Required", func() {
 		machineSet, err := createMachineSet(machinev1.MetadataServiceAuthenticationRequired)
 		Expect(err).ToNot(HaveOccurred())
 		assertIMDSavailability(machineSet, "HTTP/1.1 401 Unauthorized")
 	})
 
+	// Machines required for test: 1
+	// Reason: Deploys a pod on the node, so it requires a machine to be running.
 	It("should allow unauthorized requests to metadata service if metadataServiceOptions.authentication is Optional", func() {
 		machineSet, err := createMachineSet(machinev1.MetadataServiceAuthenticationOptional)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This PR reduces the amount of machine creation to the minimum that is required. 
- It moves the "scales up and down while respecting MaxNodesTotal [Slow][Serial]" test own context. Reducing MaxNodesTotal from 12 to 8. Also adds Eventualy for "Ensuring there are 6 machines in the cluster" at the beginning of the test. I hope that this will reduce the flakiness of this test.
- Infra test are grouped into 'When("machineset has x replicas")' contexts that set up the initial machine set replica count
    Tests with changes:
    1. "have ability to additively reconcile taints from machine to nodes" 2 -> 1 machine
    2. In "grow and decrease when scaling different machineSets simultaneously" reduces machineset2 to 2 replicas from 3
    3. "reject invalid machinesets" 2 -> 0 replicas by not using shared setup that created unused machineset as it is only webhook test.
- Reduces the scale from zero replicas from 3 to 2
- "cleanup deletion information after scale down" Reduces workload on machinesets from 3 to 2
- Reduces the spot test machineset replicas from 3 to 1
- Reduces "should return an error when removing required fields from the MachineSet providerSpec" replicas form 1 to 0
- In "should remediate unhealthy nodes" Uses maxUnhealthy instead of maxUnhealthy-1. This allows the test to use just 1 healthy and 1 unhealthy machine. + 1 replacement machine. Instead of 1 unhealthy, 3 healthy machines.