### PR TITLE
Fix spot test alternative machineset logic

### DIFF
--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -96,6 +96,9 @@ var _ = Describe("Running on Spot", framework.LabelMachines, framework.LabelSpot
 				if errors.Is(err, framework.ErrMachineNotProvisionedInsufficientCloudCapacity) {
 					By("Trying alternative machineSet because current one could not provision due to insufficient spot capacity")
 					// If machineSet cannot scale up due to insufficient capacity, try again with different machineSetParams
+					err = framework.DeleteMachineSets(client, machineSet)
+					Expect(err).ToNot(HaveOccurred(), "MachineSet should be be able to be deleted")
+					delete(delObjects, machineSet.Name)
 					framework.WaitForMachineSetsDeleted(client, machineSet)
 
 					continue


### PR DESCRIPTION
The logic that tries different machineSets when the instance type does not have spot capacity did not remove the old machineSet, but waited for that mahineSet to be deleted. This caused the spot test to fail when there was insufficient capacity for the first instance type it tried.

> MachineSet ci-op-fvk1klgj-efb8d-sn7ndxr57k still exists and does not have a deletion timestamp

This PR adds the missing call to delete the machineSet.