### PR TITLE
Make IMDS test more stable

### DIFF
--- a/pkg/providers/aws.go
+++ b/pkg/providers/aws.go
@@ -95,7 +95,7 @@ var _ = Describe("MetadataServiceOptions", framework.LabelCloudProviderSpecific,
 						Name:    "curl-metadata",
 						Image:   "registry.access.redhat.com/ubi8/ubi-minimal:latest",
 						Command: []string{"curl"},
-						Args:    []string{"-v", amiIDMetadataEndpoint},
+						Args:    []string{"-w 'HTTP_CODE:%{http_code}\n'", "-o /dev/null", "-s", amiIDMetadataEndpoint},
 					},
 				},
 			}
@@ -138,7 +138,7 @@ var _ = Describe("MetadataServiceOptions", framework.LabelCloudProviderSpecific,
 	It("should enforce auth on metadata service if metadataServiceOptions.authentication set to Required", func() {
 		machineSet, err := createMachineSet(machinev1.MetadataServiceAuthenticationRequired)
 		Expect(err).ToNot(HaveOccurred())
-		assertIMDSavailability(machineSet, "HTTP/1.1 401 Unauthorized")
+		assertIMDSavailability(machineSet, "HTTP_CODE:401")
 	})
 
 	// Machines required for test: 1
@@ -146,6 +146,6 @@ var _ = Describe("MetadataServiceOptions", framework.LabelCloudProviderSpecific,
 	It("should allow unauthorized requests to metadata service if metadataServiceOptions.authentication is Optional", func() {
 		machineSet, err := createMachineSet(machinev1.MetadataServiceAuthenticationOptional)
 		Expect(err).ToNot(HaveOccurred())
-		assertIMDSavailability(machineSet, "HTTP/1.1 200 OK")
+		assertIMDSavailability(machineSet, "HTTP_CODE:200")
 	})
 })


### PR DESCRIPTION
The curl command is sometimes missing http status header in verbose mode. I am not sure why this happens, but the IMDS works correctly, as seen by it printing correct ami. I hope that this change will make the test more stable by requesting it to print only the status code.

```
  [FAILED] Expected
      <string>: [21 bytes data]
      
100    21  100    21    0     0  21000      0 --:--:-- --:--:-- --:--:-- 21000
      * Closing connection 0
      ami-0e95030500ad17daa
  to contain substring
      <string>: HTTP/1.1 200 OK
```