### PR TITLE
OCPCLOUD-1717: Add annotation to error output

### DIFF
--- a/pkg/providers/aws.go
+++ b/pkg/providers/aws.go
@@ -120,7 +120,7 @@ var _ = Describe("MetadataServiceOptions", framework.LabelCloudProviderSpecific,
 				default:
 					return false, nil
 				}
-			}, framework.WaitMedium, framework.RetryShort).Should(BeTrue())
+			}, framework.WaitMedium, framework.RetryShort).Should(BeTrue(), "Curl pod failed to reach a ready state")
 
 			logs, err := lastLog("curl-metadata", 100, false)
 			Expect(err).ToNot(HaveOccurred(), "Failed to get logs from curl pod")


### PR DESCRIPTION
This is a second PR following https://github.com/openshift/cluster-api-actuator-pkg/pull/293 to add an annotation to improve error output/debugging for [OCPCLOUD-1717](https://issues.redhat.com/browse/OCPCLOUD-1717)