### PR TITLE
OCPCLOUD-1716: Add annotations to exceptions in operators pkg

### DIFF
--- a/pkg/operators/cluster-autoscaler-operator.go
+++ b/pkg/operators/cluster-autoscaler-operator.go
@@ -29,19 +29,19 @@ var _ = Describe("Cluster autoscaler operator should", framework.LabelOperators,
 		ctx = framework.GetContext()
 
 		gatherer, err = framework.NewGatherer()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "Failed to load gatherer")
 
 		client, err = framework.LoadClient()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 		ok := framework.WaitForValidatingWebhook(ctx, client, "autoscaling.openshift.io")
-		Expect(ok).To(BeTrue())
+		Expect(ok).To(BeTrue(), "Failed to wait for ValidatingWebhook")
 	})
 
 	AfterEach(func() {
 		specReport := CurrentSpecReport()
 		if specReport.Failed() {
-			Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed())
+			Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed(), "Failed to GatherAll")
 		}
 	})
 
@@ -57,7 +57,7 @@ var _ = Describe("Cluster autoscaler operator should", framework.LabelOperators,
 			},
 		}
 
-		Expect(client.Create(context.TODO(), invalidCA)).ToNot(Succeed())
+		Expect(client.Create(context.TODO(), invalidCA)).ToNot(Succeed(), "Failed to create invalid ClusterAutoscaler")
 	})
 
 	It("reject invalid MachineAutoscaler resources early via webhook", func() {
@@ -82,27 +82,29 @@ var _ = Describe("Cluster autoscaler operator should", framework.LabelOperators,
 			},
 		}
 
-		Expect(client.Create(context.TODO(), invalidMA)).ToNot(Succeed())
+		Expect(client.Create(context.TODO(), invalidMA)).ToNot(Succeed(), "Failed to create invalid MachineAutoscaler")
 	})
 })
 
 var _ = Describe("Cluster autoscaler operator deployment should", framework.LabelOperators, framework.LabelAutoscaler, func() {
 	It("be available", func() {
 		client, err := framework.LoadClient()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 		ctx := framework.GetContext()
-		Expect(framework.IsDeploymentAvailable(ctx, client, "cluster-autoscaler-operator", framework.MachineAPINamespace)).To(BeTrue())
+		Expect(framework.IsDeploymentAvailable(ctx, client, "cluster-autoscaler-operator", framework.MachineAPINamespace)).To(BeTrue(),
+			"Failed to wait for cluster-autoscaler-operator Deployment to be available")
 	})
 })
 
 var _ = Describe("Cluster autoscaler cluster operator status should", framework.LabelOperators, framework.LabelAutoscaler, func() {
 	It("be available", func() {
 		client, err := framework.LoadClient()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 		ctx := framework.GetContext()
 
-		Expect(framework.WaitForStatusAvailableShort(ctx, client, "cluster-autoscaler")).To(BeTrue())
+		Expect(framework.WaitForStatusAvailableShort(ctx, client, "cluster-autoscaler")).To(BeTrue(),
+			"Failed to wait for cluster-autoscaler Cluster Operator to be available")
 	})
 })

--- a/pkg/operators/cluster-machine-approver.go
+++ b/pkg/operators/cluster-machine-approver.go
@@ -18,19 +18,21 @@ var _ = Describe("Cluster Machine Approver deployment", framework.LabelOperators
 		ctx := framework.GetContext()
 
 		client, err := framework.LoadClient()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
-		Expect(framework.IsDeploymentAvailable(ctx, client, cmaDeployment, cmaNamespace)).To(BeTrue())
+		Expect(framework.IsDeploymentAvailable(ctx, client, cmaDeployment, cmaNamespace)).To(BeTrue(),
+			"Failed to wait for cluster-machine-approver Deployment to become available")
 	})
 })
 
 var _ = Describe("Cluster Machine Approver Cluster Operator Status", framework.LabelOperators, func() {
 	It("should be available", func() {
 		client, err := framework.LoadClient()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 		ctx := framework.GetContext()
 
-		Expect(framework.WaitForStatusAvailableShort(ctx, client, cmaClusterOperator)).To(BeTrue())
+		Expect(framework.WaitForStatusAvailableShort(ctx, client, cmaClusterOperator)).To(BeTrue(),
+			"Failed to wait for cluster-machine-approver Cluster Operator to be available")
 	})
 })

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -32,100 +32,112 @@ var _ = Describe(
 		BeforeEach(func() {
 			var err error
 			gatherer, err = framework.NewGatherer()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Failed to load gatherer")
 		})
 
 		AfterEach(func() {
 			specReport := CurrentSpecReport()
 			if specReport.Failed() {
-				Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed())
+				Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed(), "Failed to GatherAll")
 			}
 		})
 
 		It("be available", func() {
 			ctx := framework.GetContext()
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(framework.IsDeploymentAvailable(ctx, client, maoDeployment, framework.MachineAPINamespace)).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
+			Expect(framework.IsDeploymentAvailable(ctx, client, maoDeployment, framework.MachineAPINamespace)).To(BeTrue(),
+				fmt.Sprintf("Failed to wait for %s Deployment to become available", maoDeployment))
 		})
 
 		It("reconcile controllers deployment", func() {
 			ctx := framework.GetContext()
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 			initialDeployment, err := framework.GetDeployment(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get %s Deployment", maoManagedDeployment))
 
 			By(fmt.Sprintf("checking deployment %q is available", maoManagedDeployment))
-			Expect(framework.IsDeploymentAvailable(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue())
+			Expect(framework.IsDeploymentAvailable(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue(),
+				fmt.Sprintf("Failed to wait for %s Deployment to become available", maoManagedDeployment))
 
 			By(fmt.Sprintf("deleting deployment %q", maoManagedDeployment))
-			Expect(framework.DeleteDeployment(ctx, client, initialDeployment)).NotTo(HaveOccurred())
+			Expect(framework.DeleteDeployment(ctx, client, initialDeployment)).NotTo(HaveOccurred(),
+				fmt.Sprintf("Failed to delete %s Deployment", maoManagedDeployment))
 
 			By(fmt.Sprintf("checking deployment %q is available again", maoManagedDeployment))
-			Expect(framework.IsDeploymentAvailable(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue())
+			Expect(framework.IsDeploymentAvailable(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue(),
+				fmt.Sprintf("Failed to wait for %s Deployment to become available", maoManagedDeployment))
 
 			By(fmt.Sprintf("checking deployment %q spec matches", maoManagedDeployment))
-			Expect(framework.IsDeploymentSynced(ctx, client, initialDeployment, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue())
+			Expect(framework.IsDeploymentSynced(ctx, client, initialDeployment, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue(),
+				fmt.Sprintf("Failed verifying %s Deployment spec has been reconciled", maoManagedDeployment))
 		})
 
 		It("maintains deployment spec", func() {
 			ctx := framework.GetContext()
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 			initialDeployment, err := framework.GetDeployment(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get %s Deployment", maoManagedDeployment))
 
 			By(fmt.Sprintf("checking deployment %q is available", maoManagedDeployment))
-			Expect(framework.IsDeploymentAvailable(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue())
+			Expect(framework.IsDeploymentAvailable(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue(),
+				fmt.Sprintf("Failed to wait %s Deployment to become available", maoManagedDeployment))
 
 			changedDeployment := initialDeployment.DeepCopy()
 			changedDeployment.Spec.Replicas = pointer.Int32(0)
 
 			By(fmt.Sprintf("updating deployment %q", maoManagedDeployment))
-			Expect(framework.UpdateDeployment(ctx, client, maoManagedDeployment, framework.MachineAPINamespace, changedDeployment)).NotTo(HaveOccurred())
+			Expect(framework.UpdateDeployment(ctx, client, maoManagedDeployment, framework.MachineAPINamespace, changedDeployment)).NotTo(HaveOccurred(),
+				fmt.Sprintf("Failed to update %s Deployment", maoManagedDeployment))
 
 			By(fmt.Sprintf("checking deployment %q spec matches", maoManagedDeployment))
-			Expect(framework.IsDeploymentSynced(ctx, client, initialDeployment, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue())
+			Expect(framework.IsDeploymentSynced(ctx, client, initialDeployment, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue(),
+				fmt.Sprintf("Failed verifying %s Deployment spec has been reconciled", maoManagedDeployment))
 
 			By(fmt.Sprintf("checking deployment %q is available again", maoManagedDeployment))
-			Expect(framework.IsDeploymentAvailable(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue())
+			Expect(framework.IsDeploymentAvailable(ctx, client, maoManagedDeployment, framework.MachineAPINamespace)).To(BeTrue(),
+				fmt.Sprintf("Failed to wait for %s Deployment to become available", maoManagedDeployment))
 
 		})
 
 		It("reconcile mutating webhook configuration", func() {
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 			ctx := framework.GetContext()
 
-			Expect(framework.IsMutatingWebhookConfigurationSynced(ctx, client)).To(BeTrue())
+			Expect(framework.IsMutatingWebhookConfigurationSynced(ctx, client)).To(BeTrue(),
+				"Failed to wait for MutatingWebhookConfiguration to be in sync")
 		})
 
 		It("reconcile validating webhook configuration", func() {
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 			ctx := framework.GetContext()
 
-			Expect(framework.IsValidatingWebhookConfigurationSynced(ctx, client)).To(BeTrue())
+			Expect(framework.IsValidatingWebhookConfigurationSynced(ctx, client)).To(BeTrue(),
+				"Failed to wait for ValidatingWebhookConfiguration to be in sync")
 		})
 
 		It("recover after validating webhook configuration deletion", func() {
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 			ctx := framework.GetContext()
 
 			// Record the UID of the current ValidatingWebhookConfiguration
 			initial, err := framework.GetValidatingWebhookConfiguration(ctx, client, framework.DefaultValidatingWebhookConfiguration.Name)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(initial).ToNot(BeNil())
+			Expect(err).NotTo(HaveOccurred(), "Failed to get ValidatingWebhookConfiguration")
+			Expect(initial).ToNot(BeNil(), "ValidatingWebhookConfiguration should not be nil")
 			initialUID := initial.GetUID()
 
-			Expect(framework.DeleteValidatingWebhookConfiguration(ctx, client, initial)).To(Succeed())
+			Expect(framework.DeleteValidatingWebhookConfiguration(ctx, client, initial)).To(Succeed(),
+				"Failed to delete ValidatingWebhookConfiguration")
 
 			// Ensure that either UID changes (to show a new object) or that the existing object is gone
 			key := runtimeclient.ObjectKey{Name: initial.Name}
@@ -136,25 +148,26 @@ var _ = Describe(
 				}
 
 				return current.GetUID(), nil
-			}).ShouldNot(Equal(initialUID))
+			}).ShouldNot(Equal(initialUID), "ValidatingWebhookConfiguration should have an updated UID")
 
 			// Ensure that a new object has been created and matches expectations
-			Expect(framework.IsValidatingWebhookConfigurationSynced(ctx, client)).To(BeTrue())
+			Expect(framework.IsValidatingWebhookConfigurationSynced(ctx, client)).To(BeTrue(),
+				"Failed to wait for ValidatingWebhookConfiguration to be in sync")
 		})
 
 		It("recover after mutating webhook configuration deletion", func() {
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 			ctx := framework.GetContext()
 
 			// Record the UID of the current MutatingWebhookConfiguration
 			initial, err := framework.GetMutatingWebhookConfiguration(ctx, client, framework.DefaultMutatingWebhookConfiguration.Name)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(initial).ToNot(BeNil())
+			Expect(err).NotTo(HaveOccurred(), "Failed to get MutatingWebhookConfiguration")
+			Expect(initial).ToNot(BeNil(), "MutatingWebhookConfiguration should not be nil")
 			initialUID := initial.GetUID()
 
-			Expect(framework.DeleteMutatingWebhookConfiguration(ctx, client, initial)).To(Succeed())
+			Expect(framework.DeleteMutatingWebhookConfiguration(ctx, client, initial)).To(Succeed(), "Failed to delete MutatingWebhookConfiguration")
 
 			// Ensure that either UID changes (to show a new object) or that the existing object is gone
 			key := runtimeclient.ObjectKey{Name: initial.Name}
@@ -165,21 +178,22 @@ var _ = Describe(
 				}
 
 				return current.GetUID(), nil
-			}).ShouldNot(Equal(initialUID))
+			}).ShouldNot(Equal(initialUID), "MutatingWebhookConfiguration should have an updated UID")
 
 			// Ensure that a new object has been created and matches expectations
-			Expect(framework.IsMutatingWebhookConfigurationSynced(ctx, client)).To(BeTrue())
+			Expect(framework.IsMutatingWebhookConfigurationSynced(ctx, client)).To(BeTrue(),
+				"Failed to wait for MutatingWebhookConfiguration to be in sync")
 		})
 
 		It("maintains spec after mutating webhook configuration change and preserve caBundle", func() {
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 			ctx := framework.GetContext()
 
 			initial, err := framework.GetMutatingWebhookConfiguration(ctx, client, framework.DefaultMutatingWebhookConfiguration.Name)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(initial).ToNot(BeNil())
+			Expect(err).NotTo(HaveOccurred(), "Failed to get MutatingWebhookConfiguration")
+			Expect(initial).ToNot(BeNil(), "MutatingWebhookConfiguration should not be nil")
 
 			toUpdate := initial.DeepCopy()
 			for _, webhook := range toUpdate.Webhooks {
@@ -187,28 +201,31 @@ var _ = Describe(
 				webhook.AdmissionReviewVersions = []string{"test"}
 			}
 
-			Expect(framework.UpdateMutatingWebhookConfiguration(ctx, client, toUpdate)).To(Succeed())
+			Expect(framework.UpdateMutatingWebhookConfiguration(ctx, client, toUpdate)).To(Succeed(),
+				"Failed to update MutatingWebhookConfiguration")
 
-			Expect(framework.IsMutatingWebhookConfigurationSynced(ctx, client)).To(BeTrue())
+			Expect(framework.IsMutatingWebhookConfigurationSynced(ctx, client)).To(BeTrue(),
+				"Failed to wait for MutatingWebhookConfiguration to be in sync")
 
 			updated, err := framework.GetMutatingWebhookConfiguration(ctx, client, framework.DefaultMutatingWebhookConfiguration.Name)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updated).ToNot(BeNil())
+			Expect(err).NotTo(HaveOccurred(), "Failed to get MutatingWebhookConfiguration")
+			Expect(updated).ToNot(BeNil(), "MutatingWebhookConfiguration should not be nil")
 
 			for i, webhook := range updated.Webhooks {
-				Expect(webhook.ClientConfig.CABundle).To(Equal(initial.Webhooks[i].ClientConfig.CABundle))
+				Expect(webhook.ClientConfig.CABundle).To(Equal(initial.Webhooks[i].ClientConfig.CABundle),
+					"MutatingWebhookConfiguration CABundles should all be equal")
 			}
 		})
 
 		It("maintains spec after validating webhook configuration change and preserve caBundle", func() {
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 			ctx := framework.GetContext()
 
 			initial, err := framework.GetValidatingWebhookConfiguration(ctx, client, framework.DefaultValidatingWebhookConfiguration.Name)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(initial).ToNot(BeNil())
+			Expect(err).NotTo(HaveOccurred(), "Failed to get ValidatingWebhookConfiguration")
+			Expect(initial).ToNot(BeNil(), "ValidatingWebhookConfiguration should not be nil")
 
 			toUpdate := initial.DeepCopy()
 			for _, webhook := range toUpdate.Webhooks {
@@ -216,16 +233,19 @@ var _ = Describe(
 				webhook.AdmissionReviewVersions = []string{"test"}
 			}
 
-			Expect(framework.UpdateValidatingWebhookConfiguration(ctx, client, toUpdate)).To(Succeed())
+			Expect(framework.UpdateValidatingWebhookConfiguration(ctx, client, toUpdate)).To(Succeed(),
+				"Failed to update ValidatingWebhookConfiguration")
 
-			Expect(framework.IsValidatingWebhookConfigurationSynced(ctx, client)).To(BeTrue())
+			Expect(framework.IsValidatingWebhookConfigurationSynced(ctx, client)).To(BeTrue(),
+				"Failed to wait for ValidatingWebhookConfiguration to be in sync")
 
 			updated, err := framework.GetValidatingWebhookConfiguration(ctx, client, framework.DefaultValidatingWebhookConfiguration.Name)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updated).ToNot(BeNil())
+			Expect(err).NotTo(HaveOccurred(), "Failed to get ValidatingWebhookConfiguration")
+			Expect(updated).ToNot(BeNil(), "ValidatingWebhookConfiguration should not be nil")
 
 			for i, webhook := range updated.Webhooks {
-				Expect(webhook.ClientConfig.CABundle).To(Equal(initial.Webhooks[i].ClientConfig.CABundle))
+				Expect(webhook.ClientConfig.CABundle).To(Equal(initial.Webhooks[i].ClientConfig.CABundle),
+					"Validating Webhooks CABundles should all be equal")
 			}
 		})
 	})
@@ -236,9 +256,10 @@ var _ = Describe(
 			ctx := framework.GetContext()
 
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
-			Expect(framework.WaitForStatusAvailableShort(ctx, client, "machine-api")).To(BeTrue())
+			Expect(framework.WaitForStatusAvailableShort(ctx, client, "machine-api")).To(BeTrue(),
+				"Failed to wait for machine-api Cluster Operator to be available")
 		})
 	})
 
@@ -250,12 +271,12 @@ var _ = Describe(
 		var gatherer *gatherer.StateGatherer
 		client, err := framework.LoadClient()
 		ctx := framework.GetContext()
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 		BeforeEach(func() {
 			var err error
 			gatherer, err = framework.NewGatherer()
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Failed to load gatherer")
 
 			By("deploying an HTTP proxy")
 			framework.DeployProxy(client)
@@ -269,13 +290,13 @@ var _ = Describe(
 		It("create machines when configured behind a proxy", func() {
 			By("creating a machineset")
 			machineSet, err := framework.CreateMachineSet(client, framework.BuildMachineSetParams(ctx, client, 1))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred(), "Failed to create MachineSet")
 
 			By("waiting for the all MachineSet's Machines (and Nodes) to become Running (and Ready)")
 			framework.WaitForMachineSet(ctx, client, machineSet.GetName())
 
 			By("destroying a machineset")
-			Expect(client.Delete(context.Background(), machineSet)).To(Succeed())
+			Expect(client.Delete(context.Background(), machineSet)).To(Succeed(), "Failed to delete MachineSet")
 			framework.WaitForMachineSetsDeleted(ctx, client, machineSet)
 		})
 
@@ -285,21 +306,24 @@ var _ = Describe(
 
 			specReport := CurrentSpecReport()
 			if specReport.Failed() {
-				Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed())
+				Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed(), "Failed to GatherAll")
 			}
 
 			By("waiting for MAO, KAPI and KCM cluster operators to become available")
 			client, err := framework.LoadClient()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
 			By("waiting for KAPI cluster operator to become available")
-			Expect(framework.WaitForStatusAvailableOverLong(ctx, client, "kube-apiserver")).To(BeTrue())
+			Expect(framework.WaitForStatusAvailableOverLong(ctx, client, "kube-apiserver")).To(BeTrue(),
+				"Failed to wait for kube-apiserver Cluster Operator to become available")
 
 			By("waiting for KCM cluster operator to become available")
-			Expect(framework.WaitForStatusAvailableOverLong(ctx, client, "kube-controller-manager")).To(BeTrue())
+			Expect(framework.WaitForStatusAvailableOverLong(ctx, client, "kube-controller-manager")).To(BeTrue(),
+				"Failed to wait for kube-controller-manager Cluster Operator to become available")
 
 			By("waiting for MAO cluster operator to become available")
-			Expect(framework.WaitForStatusAvailableMedium(ctx, client, "machine-api")).To(BeTrue())
+			Expect(framework.WaitForStatusAvailableMedium(ctx, client, "machine-api")).To(BeTrue(),
+				"Failed to wait for machine-api Cluster Operator to become available")
 
 			By("Removing the mitm-proxy")
 			framework.DeleteProxy(client)


### PR DESCRIPTION
The exception statements `Except`, `Eventually`, and `Consistently` should have annotations associated with them so that debugging test failures is easier.