### PR TITLE
OCPBUGS-9925: Fix tests for OpenStack platform

### DIFF
--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -165,6 +165,17 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 		client, err = framework.LoadClient()
 		Expect(err).ToNot(HaveOccurred(), "Controller-runtime client should be able to be created")
 
+		// Reset the machineSet between each test
+		machineSet = nil
+
+		// Make sure to clean up the resources we created
+		DeferCleanup(func() {
+			if machineSet != nil {
+				By("Deleting the new MachineSet")
+				Expect(client.Delete(ctx, machineSet)).To(Succeed(), "MachineSet should be able to be deleted")
+				framework.WaitForMachineSetsDeleted(ctx, client, machineSet)
+			}
+		})
 	})
 
 	AfterEach(func() {
@@ -172,13 +183,6 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 		if specReport.Failed() {
 			Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed(), "StateGatherer should be able to gather resources")
 		}
-
-		if machineSet != nil {
-			By("Deleting the new MachineSet")
-			Expect(client.Delete(ctx, machineSet)).To(Succeed(), "MachineSet should be able to be deleted")
-			framework.WaitForMachineSetsDeleted(ctx, client, machineSet)
-		}
-
 	})
 
 	When("machineset has one replica", func() {

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -386,6 +387,19 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 	// Machines required for test: 0
 	// Reason: The machineSet creation is rejected by the webhook.
 	It("reject invalid machinesets", func() {
+		client, err := framework.LoadClient()
+		Expect(err).ToNot(HaveOccurred(), "Controller-runtime client should be able to be created")
+		// Only run on platforms that have webhooks
+		clusterInfra, err := framework.GetInfrastructure(ctx, client)
+		Expect(err).NotTo(HaveOccurred(), "Should be able to get Infrastructure")
+		platform := clusterInfra.Status.PlatformStatus.Type
+		switch platform {
+		case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType, configv1.VSpherePlatformType, configv1.PowerVSPlatformType, configv1.NutanixPlatformType:
+			// Do Nothing
+		default:
+			Skip(fmt.Sprintf("Platform %s does not have webhooks, skipping.", platform))
+		}
+
 		By("Creating invalid machineset")
 		invalidMachineSet := invalidMachinesetWithEmptyProviderConfig()
 		expectedAdmissionWebhookErr := "admission webhook \"default.machineset.machine.openshift.io\" denied the request: providerSpec.value: Required value: a value must be provided"

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -70,6 +70,19 @@ var _ = Describe("Webhooks", framework.LabelMachines, func() {
 				return framework.IsValidatingWebhookConfigurationSynced(ctx, client)
 			}, framework.WaitShort).Should(BeTrue(), "ValidingWebhookConfiguration must be synced before running these tests")
 		})
+
+		// Make sure to clean up the resources we created
+		DeferCleanup(func() {
+			machineSets, err := framework.GetMachineSets(client, testSelector)
+			Expect(err).ToNot(HaveOccurred(), "Should be able to list test MachineSets")
+			Expect(framework.DeleteMachineSets(client, machineSets...)).To(Succeed(), "Should be able to delete test MachineSets")
+			framework.WaitForMachineSetsDeleted(ctx, client, machineSets...)
+
+			machines, err := framework.GetMachines(ctx, client, testSelector)
+			Expect(err).ToNot(HaveOccurred(), "Should be able to get test Machines")
+			Expect(framework.DeleteMachines(ctx, client, machines...)).To(Succeed(), "Should be able to delete test Machines")
+			framework.WaitForMachinesDeleted(client, machines...)
+		})
 	})
 
 	AfterEach(func() {
@@ -77,16 +90,6 @@ var _ = Describe("Webhooks", framework.LabelMachines, func() {
 		if specReport.Failed() {
 			Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed(), "StateGatherer should be able to gather resources")
 		}
-
-		machineSets, err := framework.GetMachineSets(client, testSelector)
-		Expect(err).ToNot(HaveOccurred(), "Should be able to list test MachineSets")
-		Expect(framework.DeleteMachineSets(client, machineSets...)).To(Succeed(), "Should be able to delete test MachineSets")
-		framework.WaitForMachineSetsDeleted(ctx, client, machineSets...)
-
-		machines, err := framework.GetMachines(ctx, client, testSelector)
-		Expect(err).ToNot(HaveOccurred(), "Should be able to get test Machines")
-		Expect(framework.DeleteMachines(ctx, client, machines...)).To(Succeed(), "Should be able to delete test Machines")
-		framework.WaitForMachinesDeleted(client, machines...)
 	})
 
 	// Machines required for test: 1

--- a/pkg/providers/aws.go
+++ b/pkg/providers/aws.go
@@ -50,6 +50,14 @@ var _ = Describe("MetadataServiceOptions", framework.LabelCloudProviderSpecific,
 		if platform != configv1.AWSPlatformType {
 			Skip(fmt.Sprintf("skipping AWS specific tests on %s", platform))
 		}
+
+		// Make sure to clean up the resources we created
+		DeferCleanup(func() {
+			Expect(framework.DeleteMachineSets(client, toDelete...)).To(Succeed())
+			toDelete = make([]*machinev1.MachineSet, 0, 3)
+
+			framework.WaitForMachineSetsDeleted(ctx, client, toDelete...)
+		})
 	})
 
 	AfterEach(func() {
@@ -57,11 +65,6 @@ var _ = Describe("MetadataServiceOptions", framework.LabelCloudProviderSpecific,
 		if specReport.Failed() {
 			Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed())
 		}
-
-		Expect(framework.DeleteMachineSets(client, toDelete...)).To(Succeed())
-		toDelete = make([]*machinev1.MachineSet, 0, 3)
-
-		framework.WaitForMachineSetsDeleted(ctx, client, toDelete...)
 	})
 
 	createMachineSet := func(metadataAuth string) (*machinev1.MachineSet, error) {


### PR DESCRIPTION
There were several issues, the more serious one was a problem where cleanup would wipe all existing machinesets (the existing ones, before the tests ran) when the tests were skipped.

Moving the cleanup code to a `DeferCleanup()` function fixes it.