### PR TITLE
OCPBUGS-25940: Exercise availabilitySets in E2E

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -506,7 +506,7 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 			clusterAutoscaler.Spec.BalanceSimilarNodeGroups = ptr.To[bool](true)
 			// Ignore this label to make test nodes similar
 			clusterAutoscaler.Spec.BalancingIgnoredLabels = []string{
-				"e2e.openshift.io",
+				framework.MachineSetKey,
 			}
 			Expect(client.Create(ctx, clusterAutoscaler)).Should(Succeed(), "Failed to create ClusterAutoscaler")
 			cleanupObjects[clusterAutoscaler.GetName()] = clusterAutoscaler
@@ -557,11 +557,11 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 			// ensure that no extra labels have been added.
 			// TODO it would be nice to check instance types as well, this will require adding some deserialization code for the machine specs.
 			By("Ensuring both MachineSets have the same .spec.template.spec.labels")
-			// Ignore e2e.openshift.io in the comparison to test BalancingIgnoredLabels feature
+			// Ignore machine.openshift.io/cluster-api-machineset in the comparison to test BalancingIgnoredLabels feature
 			labelsMachineSetA := transientMachineSets[0].Spec.Template.Spec.Labels
-			delete(labelsMachineSetA, "e2e.openshift.io")
+			delete(labelsMachineSetA, framework.MachineSetKey)
 			labelsMachineSetB := transientMachineSets[1].Spec.Template.Spec.Labels
-			delete(labelsMachineSetB, "e2e.openshift.io")
+			delete(labelsMachineSetB, framework.MachineSetKey)
 			Expect(labelsMachineSetA).To(Equal(labelsMachineSetB), "Failed to match MachineSet labels for balancing similar nodes")
 
 			By("Waiting for all Machines in MachineSets to enter Running phase")

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -106,16 +106,15 @@ func buildMachineSetParamsFromMachineSet(ctx context.Context, client runtimeclie
 	Expect(err).NotTo(HaveOccurred(), "getting infrastructure global object should not error.")
 	Expect(clusterInfra.Status.InfrastructureName).ShouldNot(BeEmpty(), "infrastructure name was empty on Infrastructure.Status.")
 
-	uid, err := uuid.NewUUID()
-	Expect(err).NotTo(HaveOccurred(), "generating a new UUID should not fail.")
+	name := clusterInfra.Status.InfrastructureName + "-" + uuid.New().String()[0:5]
 
 	return MachineSetParams{
-		Name:         clusterInfra.Status.InfrastructureName,
+		Name:         name,
 		Replicas:     int32(replicas),
 		ProviderSpec: providerSpec,
 		Labels: map[string]string{
-			"e2e.openshift.io": uid.String(),
-			ClusterKey:         clusterName,
+			MachineSetKey: name,
+			ClusterKey:    clusterName,
 		},
 		Taints: []corev1.Taint{
 			{
@@ -144,9 +143,9 @@ func CreateMachineSet(c runtimeclient.Client, params MachineSetParams) (*machine
 			APIVersion: "machine.openshift.io/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: params.Name,
-			Namespace:    MachineAPINamespace,
-			Labels:       params.Labels,
+			Name:      params.Name,
+			Namespace: MachineAPINamespace,
+			Labels:    params.Labels,
 		},
 		Spec: machinev1.MachineSetSpec{
 			Selector: metav1.LabelSelector{


### PR DESCRIPTION
This PR sets `machine.openshift.io/cluster-api-machineset` label on machineset to enable testing of availabilitySet feature on Azure.