### PR TITLE
SPLAT-1410: Preserve AddressesFromPools when applying FailureDomain networking.

### DIFF
--- a/testutils/resourcebuilder/machine/v1beta1/vsphere_provider_spec.go
+++ b/testutils/resourcebuilder/machine/v1beta1/vsphere_provider_spec.go
@@ -95,11 +95,7 @@ func (v VSphereProviderSpecBuilder) Build() *machinev1beta1.VSphereMachineProvid
 							vSphereFailureDomain.Topology.Datacenter,
 							vSphereFailureDomain.Topology.ComputeCluster),
 					}
-					networkDevices = []machinev1beta1.NetworkDeviceSpec{
-						{
-							NetworkName: vSphereFailureDomain.Topology.Networks[0],
-						},
-					}
+					networkDevices[0].NetworkName = vSphereFailureDomain.Topology.Networks[0]
 					template = v.template
 				}
 			}


### PR DESCRIPTION
Changed logic to not fully overwrite the networking config when applying FailureDomain.  In case of CPMS, the CPMS will contain a AddressesFromPools definition for static IP.  This must not get removed w hen applying the FailureDomain's network name.