### PR TITLE
OCPBUGS-33974: Remove checking for GPU annotations in ScaleFromZero E2E tests

### DIFF
--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -255,7 +255,8 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 			framework.WaitForMachineSet(ctx, client, machineSet.GetName())
 
 			Eventually(func() (map[string]string, error) {
-				//checking for the keys of the old scalefromzero annotations before creating a machineautoscaler
+				// Checking for the keys of the old ScaleFromZero annotations before creating a MachineAutoscaler.
+				// Only checking for the CPU and Mem annotations, as some platforms do not include the GPU annotations.
 				ms, err := framework.GetMachineSet(context.TODO(), client, machineSet.GetName())
 				if err != nil {
 					return nil, err
@@ -265,7 +266,6 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 			}, framework.WaitMedium, pollingInterval).Should(SatisfyAll(
 				HaveKey(annotationsutil.CpuKeyDeprecated),
 				HaveKey(annotationsutil.MemoryKeyDeprecated),
-				HaveKey(annotationsutil.GpuCountKeyDeprecated),
 			), "No scale from zero annotations found")
 
 			expectedReplicas := int32(2)
@@ -294,23 +294,19 @@ var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() 
 				return *ms.Spec.Replicas == expectedReplicas
 			}, framework.WaitMedium, pollingInterval).Should(BeTrue(), "MachineSet %s failed to scale out to %d replicas", machineSet.GetName(), expectedReplicas)
 
-			By("checking for the presence of the scale from zero annotations")
-			Eventually(func() (bool, error) {
-				//checking for the keys of the newly added upstream annotations from the CAO
+			Eventually(func() (map[string]string, error) {
+				// Checking for the keys of the newly added upstream annotations from the CAO.
+				// Only checking for the CPU and Mem annotations, as some platforms do not include the GPU annotations.
 				ms, err := framework.GetMachineSet(context.TODO(), client, machineSet.GetName())
-				Expect(err).ToNot(HaveOccurred(), "Failed to get MachineSet %s", machineSet.GetName())
-
-				if ms.Annotations == nil {
-					return false, nil
-				} else {
-					Expect(ms.Annotations).To(HaveKey(annotationsutil.CpuKey))
-					Expect(ms.Annotations).To(HaveKey(annotationsutil.MemoryKey))
-					Expect(ms.Annotations).To(HaveKey(annotationsutil.GpuCountKey))
-					Expect(ms.Annotations).To(HaveKey(annotationsutil.GpuTypeKey))
+				if err != nil {
+					return nil, err
 				}
 
-				return true, nil
-			}, framework.WaitMedium, pollingInterval).Should(BeTrue(), "New scale from zero annotations found")
+				return ms.Annotations, nil
+			}, framework.WaitMedium, pollingInterval).Should(SatisfyAll(
+				HaveKey(annotationsutil.CpuKey),
+				HaveKey(annotationsutil.MemoryKey),
+			), "New scale from zero annotations not found")
 
 			By("Waiting for the machineSet replicas to become nodes")
 			framework.WaitForMachineSet(ctx, client, machineSet.GetName())


### PR DESCRIPTION
Hello,
another bug fix for [OCPBUGS-33974](https://issues.redhat.com/browse/OCPBUGS-33974). :)

[This PR](https://github.com/openshift/cluster-api-actuator-pkg/pull/317) was intended as a change to some ScaleFromZero E2E tests that were causing periodics on all platforms to fail - but I didn't remove the check for the deprecated GPU annotation and the new upstream GpuCount/GpuType annotations. This means the periodics for platforms that do not include the GPU annotations by default when opting in to autoscaling were still having their periodics failing. 
Another PR to fix this, and some refactoring based on [some feedback from Joel on the first PR](https://github.com/openshift/cluster-api-actuator-pkg/pull/317#discussion_r1615864941).

Thanks!