### PR TITLE
OCPCLOUD-2749: testutils: resourcebuilder: extend fields

### DIFF
--- a/testutils/resourcebuilder/coalesce.go
+++ b/testutils/resourcebuilder/coalesce.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcebuilder
+
+// Coalesce returns the first value (value) provided it is a non-zero value for the type,
+// otherwise it returns a the second value (defaultValue).
+func Coalesce[T comparable](value *T, defaultValue T) T {
+	if value == nil {
+		return defaultValue
+	}
+
+	return *value
+}

--- a/testutils/resourcebuilder/machine/v1beta1/aws_provider_spec.go
+++ b/testutils/resourcebuilder/machine/v1beta1/aws_provider_spec.go
@@ -20,48 +20,107 @@ import (
 	"encoding/json"
 
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 )
 
-// AWSProviderSpec creates a new AWS machine config builder.
-func AWSProviderSpec() AWSProviderSpecBuilder {
-	return AWSProviderSpecBuilder{
-		availabilityZone: "us-east-1a",
-		instanceType:     "m6i.xlarge",
-		securityGroups: []machinev1beta1.AWSResourceReference{
-			{
-				Filters: []machinev1beta1.Filter{
-					{
-						Name: "tag:Name",
-						Values: []string{
-							"aws-security-group-12345678",
-						},
-					},
-				},
+var (
+	defaultAMIID                 = ptr.To[string]("aws-ami-12345678")
+	defaultAvailabilityZone      = "us-east-1a"
+	defaultCredentialsSecretName = "aws-cloud-credentials"
+	defaultDeviceIndex           = int64(0)
+	defaultIAMInstanceProfile    = &machinev1beta1.AWSResourceReference{
+		ID: ptr.To[string]("aws-iam-instance-profile-12345678"),
+	}
+	defaultInstanceType  = "m6i.xlarge"
+	defaultLoadBalancers = []machinev1beta1.LoadBalancerReference{
+		{
+			Type: "network",
+			Name: "aws-nlb-int",
+		},
+		{
+			Type: "network",
+			Name: "aws-nlb-ext",
+		},
+	}
+	defaultBlockDevices = []machinev1beta1.BlockDeviceMappingSpec{
+		{
+			EBS: &machinev1beta1.EBSBlockDeviceSpec{
+				Encrypted:  ptr.To[bool](true),
+				VolumeSize: ptr.To[int64](120),
+				VolumeType: ptr.To[string]("gp3"),
 			},
 		},
-		subnet: machinev1beta1.AWSResourceReference{
+	}
+	// zero-value of the type, to play well with omitempty.
+	defaultMetadataServiceOptions = machinev1beta1.MetadataServiceOptions{}
+	// zero-value of the type, to play well with omitempty.
+	defaultNetworkInterfaceType = machinev1beta1.AWSNetworkInterfaceType("")
+	defaultPlacement            = machinev1beta1.Placement{
+		Region:           defaultRegion,
+		AvailabilityZone: defaultAvailabilityZone,
+	}
+	defaultPlacementGroupName = "" // zero-value of the type, to play well with omitempty.
+	defaultRegion             = "us-east-1"
+	defaultSecurityGroups     = []machinev1beta1.AWSResourceReference{
+		{
 			Filters: []machinev1beta1.Filter{
 				{
 					Name: "tag:Name",
 					Values: []string{
-						"aws-subnet-12345678",
+						"aws-security-group-12345678",
 					},
 				},
 			},
 		},
 	}
+	defaultSubnet = machinev1beta1.AWSResourceReference{
+		Filters: []machinev1beta1.Filter{
+			{
+				Name: "tag:Name",
+				Values: []string{
+					"aws-subnet-12345678",
+				},
+			},
+		},
+	}
+	defaultUserDataSecretName = "aws-user-data-12345678"
+)
+
+// AWSProviderSpec creates a new AWS machine config builder.
+func AWSProviderSpec() AWSProviderSpecBuilder {
+	return AWSProviderSpecBuilder{}
 }
 
 // AWSProviderSpecBuilder is used to build out a AWS machine config object.
+// All the fields of this struct are a pointer to the corresponding original type
+// in the machinev1beta1.AWSMachineProviderConfig. This is done to enable representing
+// the value not being specified in the building chain (so it can be defaulted), versus
+// it being specified, either for setting it to a custom value or to the zero-value of that type.
 type AWSProviderSpecBuilder struct {
-	availabilityZone string
-	instanceType     string
-	securityGroups   []machinev1beta1.AWSResourceReference
-	subnet           machinev1beta1.AWSResourceReference
+	ami                    *machinev1beta1.AWSResourceReference
+	availabilityZone       *string
+	blockDevices           *[]machinev1beta1.BlockDeviceMappingSpec
+	credentialsSecret      **corev1.LocalObjectReference
+	deviceIndex            *int64
+	iamInstanceProfile     **machinev1beta1.AWSResourceReference
+	instanceType           *string
+	keyName                **string
+	loadBalancers          *[]machinev1beta1.LoadBalancerReference
+	metadataServiceOptions *machinev1beta1.MetadataServiceOptions
+	networkInterfaceType   *machinev1beta1.AWSNetworkInterfaceType
+	placement              *machinev1beta1.Placement
+	placementGroupName     *string
+	publicIP               **bool
+	region                 *string
+	securityGroups         *[]machinev1beta1.AWSResourceReference
+	spotMarketOptions      **machinev1beta1.SpotMarketOptions
+	subnet                 *machinev1beta1.AWSResourceReference
+	tags                   *[]machinev1beta1.TagSpecification
+	userDataSecret         **corev1.LocalObjectReference
 }
 
 // Build builds a new AWS machine config based on the configuration provided.
@@ -71,44 +130,27 @@ func (m AWSProviderSpecBuilder) Build() *machinev1beta1.AWSMachineProviderConfig
 			APIVersion: "awsproviderconfig.openshift.io/v1beta1",
 			Kind:       "AWSMachineProviderConfig",
 		},
-		AMI: machinev1beta1.AWSResourceReference{
-			ID: ptr.To[string]("aws-ami-12345678"),
-		},
-		BlockDevices: []machinev1beta1.BlockDeviceMappingSpec{
-			{
-				EBS: &machinev1beta1.EBSBlockDeviceSpec{
-					Encrypted:  ptr.To[bool](true),
-					VolumeSize: ptr.To[int64](120),
-					VolumeType: ptr.To[string]("gp3"),
-				},
-			},
-		},
-		CredentialsSecret: &corev1.LocalObjectReference{
-			Name: "aws-cloud-credentials",
-		},
-		IAMInstanceProfile: &machinev1beta1.AWSResourceReference{
-			ID: ptr.To[string]("aws-iam-instance-profile-12345678"),
-		},
-		InstanceType: m.instanceType,
-		LoadBalancers: []machinev1beta1.LoadBalancerReference{
-			{
-				Type: "network",
-				Name: "aws-nlb-int",
-			},
-			{
-				Type: "network",
-				Name: "aws-nlb-ext",
-			},
-		},
-		Placement: machinev1beta1.Placement{
-			Region:           "us-east-1",
-			AvailabilityZone: m.availabilityZone,
-		},
-		SecurityGroups: m.securityGroups,
-		Subnet:         m.subnet,
-		UserDataSecret: &corev1.LocalObjectReference{
-			Name: "aws-user-data-12345678",
-		},
+		AMI:                    coalesceAWSResourceReference(m.ami, machinev1beta1.AWSResourceReference{ID: defaultAMIID}),
+		BlockDevices:           coalesceBlockDevices(m.blockDevices, defaultBlockDevices),
+		CredentialsSecret:      resourcebuilder.Coalesce(m.credentialsSecret, &corev1.LocalObjectReference{Name: defaultCredentialsSecretName}),
+		DeviceIndex:            resourcebuilder.Coalesce(m.deviceIndex, defaultDeviceIndex),
+		IAMInstanceProfile:     resourcebuilder.Coalesce(m.iamInstanceProfile, defaultIAMInstanceProfile),
+		InstanceType:           resourcebuilder.Coalesce(m.instanceType, defaultInstanceType),
+		KeyName:                resourcebuilder.Coalesce(m.keyName, nil),
+		LoadBalancers:          coalesceLoadBalancers(m.loadBalancers, defaultLoadBalancers),
+		MetadataServiceOptions: resourcebuilder.Coalesce(m.metadataServiceOptions, defaultMetadataServiceOptions),
+		NetworkInterfaceType:   resourcebuilder.Coalesce(m.networkInterfaceType, defaultNetworkInterfaceType),
+		Placement: resourcebuilder.Coalesce(m.placement, machinev1beta1.Placement{
+			Region:           resourcebuilder.Coalesce(m.region, defaultRegion),
+			AvailabilityZone: resourcebuilder.Coalesce(m.availabilityZone, defaultAvailabilityZone),
+		}),
+		PlacementGroupName: resourcebuilder.Coalesce(m.placementGroupName, defaultPlacementGroupName),
+		PublicIP:           resourcebuilder.Coalesce(m.publicIP, nil),
+		SecurityGroups:     coalesceAWSResourceReferences(m.securityGroups, defaultSecurityGroups),
+		SpotMarketOptions:  resourcebuilder.Coalesce(m.spotMarketOptions, nil),
+		Subnet:             coalesceAWSResourceReference(m.subnet, defaultSubnet),
+		Tags:               coalesceTags(m.tags, nil),
+		UserDataSecret:     resourcebuilder.Coalesce(m.userDataSecret, &corev1.LocalObjectReference{Name: defaultUserDataSecretName}),
 	}
 }
 
@@ -127,26 +169,124 @@ func (m AWSProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
 	}
 }
 
+// WithAMI sets the AMI for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithAMI(ami machinev1beta1.AWSResourceReference) AWSProviderSpecBuilder {
+	m.ami = &ami
+	return m
+}
+
 // WithAvailabilityZone sets the availabilityZone for the AWS machine config builder.
 func (m AWSProviderSpecBuilder) WithAvailabilityZone(az string) AWSProviderSpecBuilder {
-	m.availabilityZone = az
+	m.availabilityZone = &az
+	return m
+}
+
+// WithBlockDevices sets the BlockDevices for the AWS machine config builder.
+// Use WithBlockDevices(nil), to set them to the zero value.
+func (m AWSProviderSpecBuilder) WithBlockDevices(blockDevices []machinev1beta1.BlockDeviceMappingSpec) AWSProviderSpecBuilder {
+	m.blockDevices = &blockDevices
+	return m
+}
+
+// WithCredentialsSecret sets the CredentialsSecret for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithCredentialsSecret(credentialsSecret *corev1.LocalObjectReference) AWSProviderSpecBuilder {
+	m.credentialsSecret = &credentialsSecret
+	return m
+}
+
+// WithDeviceIndex sets the DeviceIndex for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithDeviceIndex(deviceIndex int64) AWSProviderSpecBuilder {
+	m.deviceIndex = &deviceIndex
+	return m
+}
+
+// WithIAMInstanceProfile sets the AMI for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithIAMInstanceProfile(iamInstanceProfile *machinev1beta1.AWSResourceReference) AWSProviderSpecBuilder {
+	m.iamInstanceProfile = &iamInstanceProfile
 	return m
 }
 
 // WithInstanceType sets the instanceType for the AWS machine config builder.
 func (m AWSProviderSpecBuilder) WithInstanceType(instanceType string) AWSProviderSpecBuilder {
-	m.instanceType = instanceType
+	m.instanceType = &instanceType
+	return m
+}
+
+// WithKeyName sets the keyName for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithKeyName(keyName *string) AWSProviderSpecBuilder {
+	m.keyName = &keyName
+	return m
+}
+
+// WithLoadBalancers sets the LoadBalancers for the AWS machine config builder.
+// Use WithLoadBalancers(nil), to set them to the zero value.
+func (m AWSProviderSpecBuilder) WithLoadBalancers(loadBalancers []machinev1beta1.LoadBalancerReference) AWSProviderSpecBuilder {
+	m.loadBalancers = &loadBalancers
+	return m
+}
+
+// WithMetadataServiceOptions sets the MetadataServiceOptions for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithMetadataServiceOptions(opts machinev1beta1.MetadataServiceOptions) AWSProviderSpecBuilder {
+	m.metadataServiceOptions = &opts
+	return m
+}
+
+// WithNetworkInterfaceType sets the NetworkInterfaceType for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithNetworkInterfaceType(netIntType machinev1beta1.AWSNetworkInterfaceType) AWSProviderSpecBuilder {
+	m.networkInterfaceType = &netIntType
+	return m
+}
+
+// WithPlacement sets the Placement for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithPlacement(placement machinev1beta1.Placement) AWSProviderSpecBuilder {
+	m.placement = &placement
+	return m
+}
+
+// WithPlacementGroupName sets the PlacementGroupName for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithPlacementGroupName(placementGroupName string) AWSProviderSpecBuilder {
+	m.placementGroupName = &placementGroupName
+	return m
+}
+
+// WithPublicIP sets the PublicIP for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithPublicIP(publicIP *bool) AWSProviderSpecBuilder {
+	m.publicIP = &publicIP
+	return m
+}
+
+// WithRegion sets the region for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithRegion(region string) AWSProviderSpecBuilder {
+	m.region = &region
 	return m
 }
 
 // WithSecurityGroups sets the securityGroups for the AWS machine config builder.
 func (m AWSProviderSpecBuilder) WithSecurityGroups(sgs []machinev1beta1.AWSResourceReference) AWSProviderSpecBuilder {
-	m.securityGroups = sgs
+	m.securityGroups = &sgs
+	return m
+}
+
+// WithSpotMarketOptions sets the SpotMarketOptions for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithSpotMarketOptions(opts *machinev1beta1.SpotMarketOptions) AWSProviderSpecBuilder {
+	m.spotMarketOptions = &opts
 	return m
 }
 
 // WithSubnet sets the subnet for the AWS machine config builder.
 func (m AWSProviderSpecBuilder) WithSubnet(subnet machinev1beta1.AWSResourceReference) AWSProviderSpecBuilder {
-	m.subnet = subnet
+	m.subnet = &subnet
+	return m
+}
+
+// WithTags sets the tags for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithTags(tags []machinev1beta1.TagSpecification) AWSProviderSpecBuilder {
+	m.tags = &tags
+	return m
+}
+
+// WithUserDataSecret sets the UserDataSecret for the AWS machine config builder.
+func (m AWSProviderSpecBuilder) WithUserDataSecret(userDataSecret *corev1.LocalObjectReference) AWSProviderSpecBuilder {
+	m.userDataSecret = &userDataSecret
 	return m
 }

--- a/testutils/resourcebuilder/machine/v1beta1/aws_provider_spec_test.go
+++ b/testutils/resourcebuilder/machine/v1beta1/aws_provider_spec_test.go
@@ -1,0 +1,438 @@
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("AWSProviderSpec", func() {
+	Describe("AMI", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.AMI).To(Equal(machinev1beta1.AWSResourceReference{ID: defaultAMIID}))
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			ami := machinev1beta1.AWSResourceReference{}
+			awsPs := AWSProviderSpec().WithAMI(ami).Build()
+			Expect(awsPs.AMI).To(Equal(ami))
+		})
+
+		It("should return the custom value when specified", func() {
+			ami := machinev1beta1.AWSResourceReference{ID: ptr.To[string]("custom-ami-id")}
+			awsPs := AWSProviderSpec().WithAMI(ami).Build()
+			Expect(awsPs.AMI).To(Equal(ami))
+		})
+	})
+
+	Describe("AvailabilityZone", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.Placement.AvailabilityZone).To(Equal(defaultAvailabilityZone))
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			awsPs := AWSProviderSpec().WithAvailabilityZone("").Build()
+			Expect(awsPs.Placement.AvailabilityZone).To(Equal(""))
+		})
+
+		It("should return the custom value when specified", func() {
+			customAZ := "us-west-2b"
+			awsPs := AWSProviderSpec().WithAvailabilityZone(customAZ).Build()
+			Expect(awsPs.Placement.AvailabilityZone).To(Equal(customAZ))
+		})
+	})
+
+	Describe("BlockDevices", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.BlockDevices).To(Equal(defaultBlockDevices))
+		})
+
+		It("should return nil when specified as such", func() {
+			awsPs := AWSProviderSpec().WithBlockDevices(nil).Build()
+			Expect(awsPs.BlockDevices).To(BeNil())
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			devices := []machinev1beta1.BlockDeviceMappingSpec{}
+			awsPs := AWSProviderSpec().WithBlockDevices(devices).Build()
+			Expect(awsPs.BlockDevices).To(Equal(devices))
+		})
+
+		It("should return the custom value when specified", func() {
+			customBlockDevices := []machinev1beta1.BlockDeviceMappingSpec{
+				{
+					EBS: &machinev1beta1.EBSBlockDeviceSpec{
+						VolumeSize: ptr.To[int64](100),
+						VolumeType: ptr.To[string]("gp2"),
+					},
+				},
+			}
+			awsPs := AWSProviderSpec().WithBlockDevices(customBlockDevices).Build()
+			Expect(awsPs.BlockDevices).To(Equal(customBlockDevices))
+		})
+	})
+
+	Describe("CredentialsSecret", func() {
+		It("should return the default value when not specified", func() {
+			defaultCredentialsSecret := &corev1.LocalObjectReference{
+				Name: defaultCredentialsSecretName,
+			}
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.CredentialsSecret).To(Equal(defaultCredentialsSecret))
+		})
+
+		It("should return nil when specified as such", func() {
+			var credentialsSecret *corev1.LocalObjectReference
+			awsPs := AWSProviderSpec().WithCredentialsSecret(credentialsSecret).Build()
+			Expect(awsPs.CredentialsSecret).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			customCredentialsSecret := &corev1.LocalObjectReference{Name: "custom-credentials"}
+			awsPs := AWSProviderSpec().WithCredentialsSecret(customCredentialsSecret).Build()
+			Expect(awsPs.CredentialsSecret).To(Equal(customCredentialsSecret))
+		})
+	})
+
+	Describe("DeviceIndex", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.DeviceIndex).To(Equal(defaultDeviceIndex))
+		})
+
+		It("should return the custom value when specified", func() {
+			customDeviceIndex := int64(1)
+			awsPs := AWSProviderSpec().WithDeviceIndex(customDeviceIndex).Build()
+			Expect(awsPs.DeviceIndex).To(Equal(customDeviceIndex))
+		})
+	})
+
+	Describe("IAMInstanceProfile", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.IAMInstanceProfile).To(Equal(defaultIAMInstanceProfile))
+		})
+
+		It("should return nil when specified as such", func() {
+			var iamInstanceProfile *machinev1beta1.AWSResourceReference
+			awsPs := AWSProviderSpec().WithIAMInstanceProfile(iamInstanceProfile).Build()
+			Expect(awsPs.IAMInstanceProfile).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			iamInstanceProfile := &machinev1beta1.AWSResourceReference{ID: ptr.To[string]("aws-iam-instance-profile-00000")}
+			awsPs := AWSProviderSpec().WithIAMInstanceProfile(iamInstanceProfile).Build()
+			Expect(awsPs.IAMInstanceProfile).To(Equal(iamInstanceProfile))
+		})
+	})
+
+	Describe("InstanceType", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.InstanceType).To(Equal(defaultInstanceType))
+		})
+
+		It("should return an empty string when specified as such", func() {
+			instanceType := ""
+			awsPs := AWSProviderSpec().WithInstanceType(instanceType).Build()
+			Expect(awsPs.InstanceType).To(Equal(instanceType))
+		})
+
+		It("should return the custom value when specified", func() {
+			instanceType := "c5.large"
+			awsPs := AWSProviderSpec().WithInstanceType(instanceType).Build()
+			Expect(awsPs.InstanceType).To(Equal(instanceType))
+		})
+	})
+
+	Describe("KeyName", func() {
+		It("should return nil when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.KeyName).To(BeNil())
+		})
+
+		It("should return nil when explicitly set to nil", func() {
+			awsPs := AWSProviderSpec().WithKeyName(nil).Build()
+			Expect(awsPs.KeyName).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			customKeyName := "my-key"
+			awsPs := AWSProviderSpec().WithKeyName(&customKeyName).Build()
+			Expect(*awsPs.KeyName).To(Equal(customKeyName))
+		})
+	})
+
+	Describe("LoadBalancers", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.LoadBalancers).To(Equal(defaultLoadBalancers))
+		})
+
+		It("should return nil when specified as such", func() {
+			awsPs := AWSProviderSpec().WithLoadBalancers(nil).Build()
+			Expect(awsPs.LoadBalancers).To(BeNil())
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			lbs := []machinev1beta1.LoadBalancerReference{}
+			awsPs := AWSProviderSpec().WithLoadBalancers(lbs).Build()
+			Expect(awsPs.LoadBalancers).To(Equal(lbs))
+		})
+
+		It("should return the custom value when specified", func() {
+			customLoadBalancers := []machinev1beta1.LoadBalancerReference{
+				{
+					Type: "classic",
+					Name: "custom-lb",
+				},
+			}
+			awsPs := AWSProviderSpec().WithLoadBalancers(customLoadBalancers).Build()
+			Expect(awsPs.LoadBalancers).To(Equal(customLoadBalancers))
+		})
+	})
+
+	Describe("MetadataServiceOptions", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.MetadataServiceOptions).To(Equal(defaultMetadataServiceOptions))
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			opts := machinev1beta1.MetadataServiceOptions{}
+			awsPs := AWSProviderSpec().WithMetadataServiceOptions(opts).Build()
+			Expect(awsPs.MetadataServiceOptions).To(Equal(opts))
+		})
+
+		It("should return the custom value when specified", func() {
+			customOpts := machinev1beta1.MetadataServiceOptions{
+				Authentication: "optional",
+			}
+			awsPs := AWSProviderSpec().WithMetadataServiceOptions(customOpts).Build()
+			Expect(awsPs.MetadataServiceOptions).To(Equal(customOpts))
+		})
+	})
+
+	Describe("NetworkInterfaceType", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.NetworkInterfaceType).To(Equal(defaultNetworkInterfaceType))
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			nType := machinev1beta1.AWSNetworkInterfaceType("")
+			awsPs := AWSProviderSpec().WithNetworkInterfaceType(nType).Build()
+			Expect(awsPs.NetworkInterfaceType).To(Equal(nType))
+		})
+
+		It("should return the custom value when specified", func() {
+			customType := machinev1beta1.AWSNetworkInterfaceType("efa")
+			awsPs := AWSProviderSpec().WithNetworkInterfaceType(customType).Build()
+			Expect(awsPs.NetworkInterfaceType).To(Equal(customType))
+		})
+	})
+
+	Describe("Placement", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.Placement).To(Equal(defaultPlacement))
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			placement := machinev1beta1.Placement{}
+			awsPs := AWSProviderSpec().WithPlacement(placement).Build()
+			Expect(awsPs.Placement).To(Equal(placement))
+		})
+
+		It("should return the custom value when specified", func() {
+			placement := machinev1beta1.Placement{Region: "eu-west-1"}
+			awsPs := AWSProviderSpec().WithPlacement(placement).Build()
+			Expect(awsPs.Placement).To(Equal(placement))
+		})
+	})
+
+	Describe("PlacementGroupName", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.PlacementGroupName).To(Equal(defaultPlacementGroupName))
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			awsPs := AWSProviderSpec().WithPlacementGroupName("").Build()
+			Expect(awsPs.PlacementGroupName).To(Equal(""))
+		})
+
+		It("should return the custom value when specified", func() {
+			customName := "my-placement-group"
+			awsPs := AWSProviderSpec().WithPlacementGroupName(customName).Build()
+			Expect(awsPs.PlacementGroupName).To(Equal(customName))
+		})
+	})
+
+	Describe("PublicIP", func() {
+		It("should return nil when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.PublicIP).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			customPublicIP := true
+			awsPs := AWSProviderSpec().WithPublicIP(&customPublicIP).Build()
+			Expect(*awsPs.PublicIP).To(BeTrue())
+		})
+
+		It("should return nil when explicitly set to nil", func() {
+			awsPs := AWSProviderSpec().WithPublicIP(nil).Build()
+			Expect(awsPs.PublicIP).To(BeNil())
+		})
+	})
+
+	Describe("Region", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.Placement.Region).To(Equal(defaultRegion))
+		})
+
+		It("should return an empty string when specified as such", func() {
+			region := ""
+			awsPs := AWSProviderSpec().WithRegion(region).Build()
+			Expect(awsPs.Placement.Region).To(Equal(region))
+		})
+
+		It("should return the custom value when specified", func() {
+			region := "eu-west-1"
+			awsPs := AWSProviderSpec().WithRegion(region).Build()
+			Expect(awsPs.Placement.Region).To(Equal(region))
+		})
+	})
+
+	Describe("SecurityGroups", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.SecurityGroups).To(Equal(defaultSecurityGroups))
+		})
+
+		It("should return nil when explicitly set to nil", func() {
+			awsPs := AWSProviderSpec().WithSecurityGroups(nil).Build()
+			Expect(awsPs.SecurityGroups).To(BeNil())
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			sgs := []machinev1beta1.AWSResourceReference{}
+			awsPs := AWSProviderSpec().WithSecurityGroups(sgs).Build()
+			Expect(awsPs.SecurityGroups).To(Equal(sgs))
+		})
+
+		It("should return the custom value when specified", func() {
+			customSecurityGroups := []machinev1beta1.AWSResourceReference{
+				{
+					ID: ptr.To[string]("sg-custom-id"),
+				},
+			}
+			awsPs := AWSProviderSpec().WithSecurityGroups(customSecurityGroups).Build()
+			Expect(awsPs.SecurityGroups).To(Equal(customSecurityGroups))
+		})
+	})
+
+	Describe("SpotMarketOptions", func() {
+		It("should return nil when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.SpotMarketOptions).To(BeNil())
+		})
+
+		It("should return nil when explicitly set to nil", func() {
+			awsPs := AWSProviderSpec().WithSpotMarketOptions(nil).Build()
+			Expect(awsPs.SpotMarketOptions).To(BeNil())
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			spotOpts := &machinev1beta1.SpotMarketOptions{}
+			awsPs := AWSProviderSpec().WithSpotMarketOptions(spotOpts).Build()
+			Expect(awsPs.SpotMarketOptions).To(Equal(spotOpts))
+		})
+
+		It("should return the custom value when specified", func() {
+			customSpotOpts := &machinev1beta1.SpotMarketOptions{
+				MaxPrice: ptr.To[string]("0.5"),
+			}
+			awsPs := AWSProviderSpec().WithSpotMarketOptions(customSpotOpts).Build()
+			Expect(awsPs.SpotMarketOptions).To(Equal(customSpotOpts))
+		})
+	})
+
+	Describe("Subnet", func() {
+		It("should return the default value when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.Subnet).To(Equal(defaultSubnet))
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			awsPs := AWSProviderSpec().WithSubnet(machinev1beta1.AWSResourceReference{}).Build()
+			Expect(awsPs.Subnet).To(Equal(machinev1beta1.AWSResourceReference{}))
+		})
+
+		It("should return the custom value when specified", func() {
+			customSubnet := machinev1beta1.AWSResourceReference{
+				ID: ptr.To[string]("subnet-custom-id"),
+			}
+			awsPs := AWSProviderSpec().WithSubnet(customSubnet).Build()
+			Expect(awsPs.Subnet).To(Equal(customSubnet))
+		})
+	})
+
+	Describe("Tags", func() {
+		It("should return nil when not specified", func() {
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.Tags).To(BeNil())
+		})
+
+		It("should return a non-nil, empty value when specified as such", func() {
+			tags := []machinev1beta1.TagSpecification{}
+			awsPs := AWSProviderSpec().WithTags(tags).Build()
+			Expect(awsPs.Tags).To(Equal(tags))
+		})
+
+		It("should return nil when explicitly set to nil", func() {
+			awsPs := AWSProviderSpec().WithTags(nil).Build()
+			Expect(awsPs.Tags).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			customTags := []machinev1beta1.TagSpecification{
+				{
+					Name:  "custom-tag",
+					Value: "custom-value",
+				},
+			}
+			awsPs := AWSProviderSpec().WithTags(customTags).Build()
+			Expect(awsPs.Tags).To(Equal(customTags))
+		})
+	})
+
+	Describe("UserDataSecret", func() {
+		It("should return the default value when not specified", func() {
+			defaultUserDataSecret := &corev1.LocalObjectReference{
+				Name: defaultUserDataSecretName,
+			}
+			awsPs := AWSProviderSpec().Build()
+			Expect(awsPs.UserDataSecret).To(Equal(defaultUserDataSecret))
+		})
+
+		It("should return nil when specified as such", func() {
+			awsPs := AWSProviderSpec().WithUserDataSecret(nil).Build()
+			Expect(awsPs.UserDataSecret).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			userDataSecret := &corev1.LocalObjectReference{Name: "bla"}
+			awsPs := AWSProviderSpec().WithUserDataSecret(userDataSecret).Build()
+			Expect(awsPs.UserDataSecret).To(Equal(userDataSecret))
+		})
+	})
+})

--- a/testutils/resourcebuilder/machine/v1beta1/coalesce.go
+++ b/testutils/resourcebuilder/machine/v1beta1/coalesce.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+)
+
+func coalesceAWSResourceReference(v1 *machinev1beta1.AWSResourceReference, v2 machinev1beta1.AWSResourceReference) machinev1beta1.AWSResourceReference {
+	if v1 == nil {
+		return v2
+	}
+
+	return *v1
+}
+
+func coalesceAWSResourceReferences(v1 *[]machinev1beta1.AWSResourceReference, v2 []machinev1beta1.AWSResourceReference) []machinev1beta1.AWSResourceReference {
+	if v1 == nil {
+		return v2
+	}
+
+	return *v1
+}
+
+func coalesceLoadBalancers(v1 *[]machinev1beta1.LoadBalancerReference, v2 []machinev1beta1.LoadBalancerReference) []machinev1beta1.LoadBalancerReference {
+	if v1 == nil {
+		return v2
+	}
+
+	return *v1
+}
+
+func coalesceBlockDevices(v1 *[]machinev1beta1.BlockDeviceMappingSpec, v2 []machinev1beta1.BlockDeviceMappingSpec) []machinev1beta1.BlockDeviceMappingSpec {
+	if v1 == nil {
+		return v2
+	}
+
+	return *v1
+}
+
+func coalesceTags(v1 *[]machinev1beta1.TagSpecification, v2 []machinev1beta1.TagSpecification) []machinev1beta1.TagSpecification {
+	if v1 == nil {
+		return v2
+	}
+
+	return *v1
+}

--- a/testutils/resourcebuilder/machine/v1beta1/coalesce.go
+++ b/testutils/resourcebuilder/machine/v1beta1/coalesce.go
@@ -18,6 +18,8 @@ package v1beta1
 
 import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func coalesceAWSResourceReference(v1 *machinev1beta1.AWSResourceReference, v2 machinev1beta1.AWSResourceReference) machinev1beta1.AWSResourceReference {
@@ -53,6 +55,38 @@ func coalesceBlockDevices(v1 *[]machinev1beta1.BlockDeviceMappingSpec, v2 []mach
 }
 
 func coalesceTags(v1 *[]machinev1beta1.TagSpecification, v2 []machinev1beta1.TagSpecification) []machinev1beta1.TagSpecification {
+	if v1 == nil {
+		return v2
+	}
+
+	return *v1
+}
+
+func coalesceMachineSpec(v1 *machinev1beta1.MachineSpec, v2 machinev1beta1.MachineSpec) machinev1beta1.MachineSpec {
+	if v1 == nil {
+		return v2
+	}
+
+	return *v1
+}
+
+func coalesceLifecycleHooks(v1 *machinev1beta1.LifecycleHooks, v2 machinev1beta1.LifecycleHooks) machinev1beta1.LifecycleHooks {
+	if v1 == nil {
+		return v2
+	}
+
+	return *v1
+}
+
+func coalesceProviderSpecValue(v1 *resourcebuilder.RawExtensionBuilder) *runtime.RawExtension {
+	if v1 == nil {
+		return nil
+	}
+
+	return (*v1).BuildRawExtension()
+}
+
+func coalesceMachineSpecObjectMeta(v1 *machinev1beta1.ObjectMeta, v2 machinev1beta1.ObjectMeta) machinev1beta1.ObjectMeta {
 	if v1 == nil {
 		return v2
 	}

--- a/testutils/resourcebuilder/machine/v1beta1/coalesce.go
+++ b/testutils/resourcebuilder/machine/v1beta1/coalesce.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -70,14 +71,6 @@ func coalesceMachineSpec(v1 *machinev1beta1.MachineSpec, v2 machinev1beta1.Machi
 	return *v1
 }
 
-func coalesceLifecycleHooks(v1 *machinev1beta1.LifecycleHooks, v2 machinev1beta1.LifecycleHooks) machinev1beta1.LifecycleHooks {
-	if v1 == nil {
-		return v2
-	}
-
-	return *v1
-}
-
 func coalesceProviderSpecValue(v1 *resourcebuilder.RawExtensionBuilder) *runtime.RawExtension {
 	if v1 == nil {
 		return nil
@@ -86,7 +79,7 @@ func coalesceProviderSpecValue(v1 *resourcebuilder.RawExtensionBuilder) *runtime
 	return (*v1).BuildRawExtension()
 }
 
-func coalesceMachineSpecObjectMeta(v1 *machinev1beta1.ObjectMeta, v2 machinev1beta1.ObjectMeta) machinev1beta1.ObjectMeta {
+func coalesceMachineSetSpecSelector(v1 *metav1.LabelSelector, v2 metav1.LabelSelector) metav1.LabelSelector {
 	if v1 == nil {
 		return v2
 	}

--- a/testutils/resourcebuilder/machine/v1beta1/machine.go
+++ b/testutils/resourcebuilder/machine/v1beta1/machine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Machine creates a new machine builder.
@@ -30,45 +31,69 @@ func Machine() MachineBuilder {
 
 // MachineBuilder is used to build out a machine object.
 type MachineBuilder struct {
-	generateName        string
-	name                string
-	namespace           string
-	labels              map[string]string
-	creationTimestamp   metav1.Time
-	deletionTimestamp   *metav1.Time
-	providerSpecBuilder resourcebuilder.RawExtensionBuilder
-	providerID          *string
+	authoritativeAPI      machinev1beta1.MachineAuthority
+	annotations           map[string]string
+	creationTimestamp     metav1.Time
+	deletionTimestamp     *metav1.Time
+	generateName          string
+	labels                map[string]string
+	lifecycleHooks        machinev1beta1.LifecycleHooks
+	machineSpec           *machinev1beta1.MachineSpec
+	machineSpecObjectMeta machinev1beta1.ObjectMeta
+	name                  string
+	namespace             string
+	providerID            **string
+	providerSpecBuilder   *resourcebuilder.RawExtensionBuilder
+	providerSpec          *machinev1beta1.ProviderSpec
+	taints                []corev1.Taint
 
 	// status fields
-	errorMessage *string
-	nodeRef      *corev1.ObjectReference
-	phase        *string
+	addresses              []corev1.NodeAddress
+	authoritativeAPIStatus machinev1beta1.MachineAuthority
+	conditions             []machinev1beta1.Condition
+	errorMessage           *string
+	errorReason            *machinev1beta1.MachineStatusError
+	lastOperation          *machinev1beta1.LastOperation
+	lastUpdated            *metav1.Time
+	nodeRef                *corev1.ObjectReference
+	phase                  *string
+	providerStatus         *runtime.RawExtension
 }
 
 // Build builds a new machine based on the configuration provided.
 func (m MachineBuilder) Build() *machinev1beta1.Machine {
 	machine := &machinev1beta1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName:      m.generateName,
+			Annotations:       m.annotations,
 			CreationTimestamp: m.creationTimestamp,
 			DeletionTimestamp: m.deletionTimestamp,
+			GenerateName:      m.generateName,
+			Labels:            m.labels,
 			Name:              m.name,
 			Namespace:         m.namespace,
-			Labels:            m.labels,
 		},
+		Spec: coalesceMachineSpec(m.machineSpec, machinev1beta1.MachineSpec{
+			AuthoritativeAPI: m.authoritativeAPI,
+			LifecycleHooks:   m.lifecycleHooks,
+			ObjectMeta:       m.machineSpecObjectMeta,
+			ProviderID:       resourcebuilder.Coalesce(m.providerID, nil),
+			ProviderSpec: resourcebuilder.Coalesce(m.providerSpec, machinev1beta1.ProviderSpec{
+				Value: coalesceProviderSpecValue(m.providerSpecBuilder),
+			}),
+			Taints: m.taints,
+		}),
 		Status: machinev1beta1.MachineStatus{
-			ErrorMessage: m.errorMessage,
-			Phase:        m.phase,
-			NodeRef:      m.nodeRef,
+			AuthoritativeAPI: m.authoritativeAPIStatus,
+			Addresses:        m.addresses,
+			Conditions:       m.conditions,
+			ErrorMessage:     m.errorMessage,
+			ErrorReason:      m.errorReason,
+			LastOperation:    m.lastOperation,
+			LastUpdated:      m.lastUpdated,
+			NodeRef:          m.nodeRef,
+			Phase:            m.phase,
+			ProviderStatus:   m.providerStatus,
 		},
-	}
-
-	if m.providerSpecBuilder != nil {
-		machine.Spec.ProviderSpec.Value = m.providerSpecBuilder.BuildRawExtension()
-	}
-
-	if m.providerID != nil {
-		machine.Spec.ProviderID = m.providerID
 	}
 
 	m.WithLabel(machinev1beta1.MachineClusterIDLabel, resourcebuilder.TestClusterIDValue)
@@ -88,6 +113,18 @@ func (m MachineBuilder) AsMaster() MachineBuilder {
 	return m.
 		WithLabel(resourcebuilder.MachineRoleLabelName, "master").
 		WithLabel(resourcebuilder.MachineTypeLabelName, "master")
+}
+
+// WithAnnotations sets the annotations for the machine builder.
+func (m MachineBuilder) WithAnnotations(annotations map[string]string) MachineBuilder {
+	m.annotations = annotations
+	return m
+}
+
+// WithAuthoritativeAPI sets the authoritativeAPI for the machine builder.
+func (m MachineBuilder) WithAuthoritativeAPI(authority machinev1beta1.MachineAuthority) MachineBuilder {
+	m.authoritativeAPI = authority
+	return m
 }
 
 // WithCreationTimestamp sets the creationTimestamp for the machine builder.
@@ -127,6 +164,24 @@ func (m MachineBuilder) WithLabels(labels map[string]string) MachineBuilder {
 	return m
 }
 
+// WithLifecycleHooks sets the lifecycleHooks for the machine builder.
+func (m MachineBuilder) WithLifecycleHooks(lh machinev1beta1.LifecycleHooks) MachineBuilder {
+	m.lifecycleHooks = lh
+	return m
+}
+
+// WithMachineSpec sets the MachineSpec field for the machine builder.
+func (m MachineBuilder) WithMachineSpec(machineSpec machinev1beta1.MachineSpec) MachineBuilder {
+	m.machineSpec = &machineSpec
+	return m
+}
+
+// WithMachineSpecObjectMeta sets the ObjectMeta on the machine spec field for the machine builder.
+func (m MachineBuilder) WithMachineSpecObjectMeta(machineSpecObjectMeta machinev1beta1.ObjectMeta) MachineBuilder {
+	m.machineSpecObjectMeta = machineSpecObjectMeta
+	return m
+}
+
 // WithName sets the name for the machine builder.
 func (m MachineBuilder) WithName(name string) MachineBuilder {
 	m.name = name
@@ -139,19 +194,49 @@ func (m MachineBuilder) WithNamespace(namespace string) MachineBuilder {
 	return m
 }
 
-// WithProviderID sets the providerID field for the machine builder.
-func (m MachineBuilder) WithProviderID(providerID string) MachineBuilder {
-	m.providerID = &providerID
+// WithProviderID sets the providerID builder for the machine builder.
+func (m MachineBuilder) WithProviderID(id *string) MachineBuilder {
+	m.providerID = &id
+	return m
+}
+
+// WithProviderSpec sets the ProviderSpec field for the machine builder.
+func (m MachineBuilder) WithProviderSpec(providerSpec machinev1beta1.ProviderSpec) MachineBuilder {
+	m.providerSpec = &providerSpec
 	return m
 }
 
 // WithProviderSpecBuilder sets the providerSpec builder for the machine builder.
 func (m MachineBuilder) WithProviderSpecBuilder(builder resourcebuilder.RawExtensionBuilder) MachineBuilder {
-	m.providerSpecBuilder = builder
+	m.providerSpecBuilder = &builder
+	return m
+}
+
+// WithTaints sets the taints field for the machine builder.
+func (m MachineBuilder) WithTaints(taints []corev1.Taint) MachineBuilder {
+	m.taints = taints
 	return m
 }
 
 // Status Fields
+
+// WithAddresses sets the addresses status field for the machine builder.
+func (m MachineBuilder) WithAddresses(addrs []corev1.NodeAddress) MachineBuilder {
+	m.addresses = addrs
+	return m
+}
+
+// WithAuthoritativeAPIStatus sets the authoritativeAPIStatus for the machine builder.
+func (m MachineBuilder) WithAuthoritativeAPIStatus(authority machinev1beta1.MachineAuthority) MachineBuilder {
+	m.authoritativeAPIStatus = authority
+	return m
+}
+
+// WithConditions sets the conditions status field for the machine builder.
+func (m MachineBuilder) WithConditions(c []machinev1beta1.Condition) MachineBuilder {
+	m.conditions = c
+	return m
+}
 
 // WithErrorMessage sets the error message status field for the machine builder.
 func (m MachineBuilder) WithErrorMessage(errorMsg string) MachineBuilder {
@@ -159,9 +244,33 @@ func (m MachineBuilder) WithErrorMessage(errorMsg string) MachineBuilder {
 	return m
 }
 
+// WithErrorReason sets the error reason status field for the machine builder.
+func (m MachineBuilder) WithErrorReason(errorReason machinev1beta1.MachineStatusError) MachineBuilder {
+	m.errorReason = &errorReason
+	return m
+}
+
+// WithLastOperation sets the lastOperation for the machine builder.
+func (m MachineBuilder) WithLastOperation(l machinev1beta1.LastOperation) MachineBuilder {
+	m.lastOperation = &l
+	return m
+}
+
+// WithLastUpdated sets the lastUpdated for the machine builder.
+func (m MachineBuilder) WithLastUpdated(l metav1.Time) MachineBuilder {
+	m.lastUpdated = &l
+	return m
+}
+
 // WithPhase sets the phase status field for the machine builder.
 func (m MachineBuilder) WithPhase(phase string) MachineBuilder {
 	m.phase = &phase
+	return m
+}
+
+// WithProviderStatus sets the providerStatus builder for the machine builder.
+func (m MachineBuilder) WithProviderStatus(ps runtime.RawExtension) MachineBuilder {
+	m.providerStatus = &ps
 	return m
 }
 

--- a/testutils/resourcebuilder/machine/v1beta1/machine_test.go
+++ b/testutils/resourcebuilder/machine/v1beta1/machine_test.go
@@ -1,0 +1,367 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-api-actuator-pkg/testutils/resourcebuilder"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("Machine", func() {
+	Describe("Build", func() {
+		It("should return a default machine when no options are specified", func() {
+			machine := Machine().Build()
+			Expect(machine).ToNot(BeNil())
+		})
+	})
+
+	Describe("AsWorker", func() {
+		It("should return the custom value when specified", func() {
+			machine := Machine().AsWorker().Build()
+			Expect(machine.Labels).To(HaveKeyWithValue(resourcebuilder.MachineRoleLabelName, "worker"))
+			Expect(machine.Labels).To(HaveKeyWithValue(resourcebuilder.MachineTypeLabelName, "worker"))
+		})
+	})
+
+	Describe("AsMaster", func() {
+		It("should return the custom value when specified", func() {
+			machine := Machine().AsMaster().Build()
+			Expect(machine.Labels).To(HaveKeyWithValue(resourcebuilder.MachineRoleLabelName, "master"))
+			Expect(machine.Labels).To(HaveKeyWithValue(resourcebuilder.MachineTypeLabelName, "master"))
+		})
+	})
+
+	Describe("WithAnnotations", func() {
+		It("should return the custom value when specified", func() {
+			annotations := map[string]string{"key": "value"}
+			machine := Machine().WithAnnotations(annotations).Build()
+			Expect(machine.Annotations).To(Equal(annotations))
+		})
+
+		It("should return nil when specified as such", func() {
+			machine := Machine().WithAnnotations(nil).Build()
+			Expect(machine.Annotations).To(BeNil())
+		})
+
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Annotations).To(BeNil())
+		})
+	})
+
+	Describe("WithAuthoritativeAPI", func() {
+		It("should return the default value when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Spec.AuthoritativeAPI).To(BeZero())
+		})
+
+		It("should return the custom value when specified", func() {
+			machine := Machine().WithAuthoritativeAPI(machinev1beta1.MachineAuthorityMachineAPI).Build()
+			Expect(machine.Spec.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityMachineAPI))
+		})
+	})
+
+	Describe("WithCreationTimestamp", func() {
+		It("should return the custom value when specified", func() {
+			timestamp := metav1.Now()
+			machine := Machine().WithCreationTimestamp(timestamp).Build()
+			Expect(machine.CreationTimestamp).To(Equal(timestamp))
+		})
+	})
+
+	Describe("WithDeletionTimestamp", func() {
+		It("should return the custom value when specified", func() {
+			timestamp := metav1.Now()
+			machine := Machine().WithDeletionTimestamp(&timestamp).Build()
+			Expect(machine.DeletionTimestamp).To(Equal(&timestamp))
+		})
+	})
+
+	Describe("WithGenerateName", func() {
+		It("should return the custom value when specified", func() {
+			generateName := "test-"
+			machine := Machine().WithGenerateName(generateName).Build()
+			Expect(machine.GenerateName).To(Equal(generateName))
+		})
+	})
+
+	Describe("WithLabel", func() {
+		It("should return the custom value when specified", func() {
+			machine := Machine().WithLabel("key", "value").Build()
+			Expect(machine.Labels).To(HaveKeyWithValue("key", "value"))
+		})
+	})
+
+	Describe("WithLabels", func() {
+		It("should return the custom value when specified", func() {
+			labels := map[string]string{"key1": "value1", "key2": "value2"}
+			machine := Machine().WithLabels(labels).Build()
+			Expect(machine.Labels).To(Equal(labels))
+		})
+
+		It("should return nil when specified as such", func() {
+			machine := Machine().WithLabels(nil).Build()
+			Expect(machine.Annotations).To(BeNil())
+		})
+
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Annotations).To(BeNil())
+		})
+	})
+
+	Describe("WithLifecycleHooks", func() {
+		It("should set default LifecycleHooks when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Spec.LifecycleHooks).To(BeZero())
+		})
+
+		It("should return the custom value when specified", func() {
+			hooks := machinev1beta1.LifecycleHooks{PreDrain: []machinev1beta1.LifecycleHook{{Name: "test-hook"}}}
+			machine := Machine().WithLifecycleHooks(hooks).Build()
+			Expect(machine.Spec.LifecycleHooks).To(Equal(hooks))
+		})
+	})
+
+	Describe("WithMachineSpec", func() {
+		It("should return the default value when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Spec).To(Not(BeNil()))
+		})
+
+		It("should return the custom value when specified", func() {
+			machineSpec := machinev1beta1.MachineSpec{}
+			machine := Machine().WithMachineSpec(machineSpec).Build()
+			Expect(machine.Spec).To(Equal(machineSpec))
+		})
+	})
+
+	Describe("WithMachineSpecObjectMeta", func() {
+		It("should return the default value when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Spec.ObjectMeta).To(BeZero())
+		})
+
+		It("should return the custom value when specified", func() {
+			objectMeta := machinev1beta1.ObjectMeta{Labels: map[string]string{"key": "value"}}
+			machine := Machine().WithMachineSpecObjectMeta(objectMeta).Build()
+			Expect(machine.Spec.ObjectMeta).To(Equal(objectMeta))
+		})
+	})
+
+	Describe("WithName", func() {
+		It("should return the custom value when specified", func() {
+			name := "test-machine"
+			machine := Machine().WithName(name).Build()
+			Expect(machine.Name).To(Equal(name))
+		})
+	})
+
+	Describe("WithNamespace", func() {
+		It("should return the custom value when specified", func() {
+			namespace := "test-namespace"
+			machine := Machine().WithNamespace(namespace).Build()
+			Expect(machine.Namespace).To(Equal(namespace))
+		})
+	})
+
+	Describe("WithProviderID", func() {
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Spec.ProviderID).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			providerID := "test-provider-id"
+			machine := Machine().WithProviderID(&providerID).Build()
+			Expect(*machine.Spec.ProviderID).To(Equal(providerID))
+		})
+	})
+
+	Describe("WithProviderSpec", func() {
+		It("should return the default value when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Spec.ProviderSpec).To(Not(BeNil()))
+		})
+
+		It("should return the custom value when specified", func() {
+			providerSpec := machinev1beta1.ProviderSpec{Value: nil}
+			machine := Machine().WithProviderSpec(providerSpec).Build()
+			Expect(machine.Spec.ProviderSpec).To(Equal(providerSpec))
+		})
+	})
+
+	Describe("WithProviderSpecBuilder", func() {
+		It("should return the custom value when specified", func() {
+			provideSpecBuilder := AWSProviderSpec()
+			machine := Machine().WithProviderSpecBuilder(provideSpecBuilder).Build()
+			Expect(machine.Spec.ProviderSpec.Value).ToNot(BeNil())
+		})
+	})
+
+	Describe("WithTaints", func() {
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Spec.Taints).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			taints := []corev1.Taint{
+				{Key: "a", Effect: corev1.TaintEffectNoExecute},
+			}
+			machine := Machine().WithTaints(taints).Build()
+			Expect(machine.Spec.Taints).To(Equal(taints))
+		})
+	})
+
+	// Status field tests
+
+	Describe("WithAddresses", func() {
+		It("should return the custom value when specified", func() {
+			addresses := []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "192.168.0.1"}}
+			machine := Machine().WithAddresses(addresses).Build()
+			Expect(machine.Status.Addresses).To(Equal(addresses))
+		})
+	})
+
+	Describe("WithAuthoritativeAPIStatus", func() {
+		It("should return the default value when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Status.AuthoritativeAPI).To(BeZero())
+		})
+
+		It("should return the custom value when specified", func() {
+			machine := Machine().WithAuthoritativeAPIStatus(machinev1beta1.MachineAuthorityMachineAPI).Build()
+			Expect(machine.Status.AuthoritativeAPI).To(Equal(machinev1beta1.MachineAuthorityMachineAPI))
+		})
+	})
+
+	Describe("WithConditions", func() {
+		It("should return the custom value when specified", func() {
+			conditions := []machinev1beta1.Condition{{Type: "Ready", Status: corev1.ConditionTrue}}
+			machine := Machine().WithConditions(conditions).Build()
+			Expect(machine.Status.Conditions).To(Equal(conditions))
+		})
+
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Status.Conditions).To(BeNil())
+		})
+
+		It("should return nil when specified as such", func() {
+			machine := Machine().WithConditions(nil).Build()
+			Expect(machine.Status.Conditions).To(BeNil())
+		})
+	})
+
+	Describe("WithErrorMessage", func() {
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Status.ErrorMessage).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			errorMessage := "test error"
+			machine := Machine().WithErrorMessage(errorMessage).Build()
+			Expect(*machine.Status.ErrorMessage).To(Equal(errorMessage))
+		})
+	})
+
+	Describe("WithErrorReason", func() {
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Status.ErrorReason).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			errorReason := machinev1beta1.CreateMachineError
+			machine := Machine().WithErrorReason(errorReason).Build()
+			Expect(*machine.Status.ErrorReason).To(Equal(errorReason))
+		})
+	})
+
+	Describe("WithLastOperation", func() {
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Status.LastOperation).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			t := "test operation"
+			lastOperation := machinev1beta1.LastOperation{Description: &t}
+			machine := Machine().WithLastOperation(lastOperation).Build()
+			Expect(*machine.Status.LastOperation).To(Equal(lastOperation))
+		})
+	})
+
+	Describe("WithLastUpdated", func() {
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Status.LastUpdated).To(BeNil())
+		})
+		It("should return the custom value when specified", func() {
+			lastUpdated := metav1.Now()
+			machine := Machine().WithLastUpdated(lastUpdated).Build()
+			Expect(*machine.Status.LastUpdated).To(Equal(lastUpdated))
+		})
+	})
+
+	Describe("WithPhase", func() {
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Status.Phase).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			phase := machinev1beta1.PhaseRunning
+			machine := Machine().WithPhase(phase).Build()
+			Expect(*machine.Status.Phase).To(Equal(phase))
+		})
+	})
+
+	Describe("WithProviderStatus", func() {
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Status.ProviderStatus).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			providerStatus := runtime.RawExtension{Raw: []byte(`{"key":"value"}`)}
+			machine := Machine().WithProviderStatus(providerStatus).Build()
+			Expect(*machine.Status.ProviderStatus).To(Equal(providerStatus))
+		})
+	})
+
+	Describe("WithNodeRef", func() {
+		It("should return nil when not specified", func() {
+			machine := Machine().Build()
+			Expect(machine.Status.NodeRef).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			nodeRef := corev1.ObjectReference{Name: "test-node", Namespace: "default"}
+			machine := Machine().WithNodeRef(nodeRef).Build()
+			Expect(*machine.Status.NodeRef).To(Equal(nodeRef))
+		})
+	})
+})

--- a/testutils/resourcebuilder/machine/v1beta1/machineset_test.go
+++ b/testutils/resourcebuilder/machine/v1beta1/machineset_test.go
@@ -1,0 +1,447 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("MachineSet", func() {
+	Describe("Build", func() {
+		It("should return a default machineSet when no options are specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet).ToNot(BeNil())
+		})
+	})
+
+	Describe("AsWorker", func() {
+		It("should set the worker role and type labels", func() {
+			machineSet := MachineSet().AsWorker().Build()
+			Expect(machineSet.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue(machineSetMachineRoleLabelName, "worker"))
+			Expect(machineSet.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue(machineSetMachineTypeLabelName, "worker"))
+		})
+	})
+
+	Describe("WithAnnotations", func() {
+		It("should return the custom value when specified", func() {
+			annotations := map[string]string{"key": "value"}
+			machineSet := MachineSet().WithAnnotations(annotations).Build()
+			Expect(machineSet.Annotations).To(Equal(annotations))
+		})
+
+		It("should return nil when specified as such", func() {
+			machineSet := MachineSet().WithAnnotations(nil).Build()
+			Expect(machineSet.Annotations).To(BeNil())
+		})
+
+		It("should return nil when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Annotations).To(BeNil())
+		})
+	})
+
+	Describe("WithAuthoritativeAPI", func() {
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.AuthoritativeAPI).To(BeZero())
+		})
+
+		It("should return the custom value when specified", func() {
+			authority := machinev1beta1.MachineAuthorityMachineAPI
+			machineSet := MachineSet().WithAuthoritativeAPI(authority).Build()
+			Expect(machineSet.Spec.AuthoritativeAPI).To(Equal(authority))
+		})
+	})
+
+	Describe("WithCreationTimestamp", func() {
+		It("should return the custom value when specified", func() {
+			timestamp := metav1.Now()
+			machineSet := MachineSet().WithCreationTimestamp(timestamp).Build()
+			Expect(machineSet.CreationTimestamp).To(Equal(timestamp))
+		})
+	})
+
+	Describe("WithDeletePolicy", func() {
+		It("should return the custom value when specified", func() {
+			policy := "Random"
+			machineSet := MachineSet().WithDeletePolicy(policy).Build()
+			Expect(machineSet.Spec.DeletePolicy).To(Equal(policy))
+		})
+	})
+
+	Describe("WithDeletionTimestamp", func() {
+		It("should return the custom value when specified", func() {
+			timestamp := metav1.Now()
+			machineSet := MachineSet().WithDeletionTimestamp(&timestamp).Build()
+			Expect(machineSet.DeletionTimestamp).To(Equal(&timestamp))
+		})
+	})
+
+	Describe("WithGenerateName", func() {
+		It("should return the custom value when specified", func() {
+			generateName := "test-"
+			machineSet := MachineSet().WithGenerateName(generateName).Build()
+			Expect(machineSet.GenerateName).To(Equal(generateName))
+		})
+	})
+
+	Describe("WithLabel", func() {
+		It("should return the custom value when specified", func() {
+			machineSet := MachineSet().WithLabel("key", "value").Build()
+			Expect(machineSet.ObjectMeta.Labels).To(HaveKeyWithValue("key", "value"))
+		})
+	})
+
+	Describe("WithLabels", func() {
+		It("should return the custom value when specified", func() {
+			labels := map[string]string{"key1": "value1", "key2": "value2"}
+			machineSet := MachineSet().WithLabels(labels).Build()
+			Expect(machineSet.ObjectMeta.Labels).To(Equal(labels))
+		})
+
+		It("should return nil when specified as such", func() {
+			machineSet := MachineSet().WithLabels(nil).Build()
+			Expect(machineSet.ObjectMeta.Labels).To(BeNil())
+		})
+
+		It("should return nil when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.ObjectMeta.Labels).To(BeNil())
+		})
+	})
+
+	Describe("WithLifecycleHooks", func() {
+		It("should set default when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.Template.Spec.LifecycleHooks).To(BeZero())
+		})
+
+		It("should set the lifecycle hooks", func() {
+			hooks := machinev1beta1.LifecycleHooks{
+				PreDrain: []machinev1beta1.LifecycleHook{{Name: "test-hook"}},
+			}
+			machineSet := MachineSet().WithLifecycleHooks(hooks).Build()
+			Expect(machineSet.Spec.Template.Spec.LifecycleHooks).To(Equal(hooks))
+		})
+	})
+
+	Describe("WithMachineSpec", func() {
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.Template.Spec).To(Not(BeNil()))
+		})
+
+		It("should return the custom value when specified", func() {
+			spec := machinev1beta1.MachineSpec{
+				ProviderID: ptr.To("test-provider-id"),
+			}
+			machineSet := MachineSet().WithMachineSpec(spec).Build()
+			Expect(machineSet.Spec.Template.Spec).To(Equal(spec))
+		})
+	})
+
+	Describe("WithMachineSpecObjectMeta", func() {
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.Template.Spec.ObjectMeta).To(BeZero())
+		})
+
+		It("should return the custom value when specified", func() {
+			meta := machinev1beta1.ObjectMeta{
+				Labels: map[string]string{"test": "label"},
+			}
+			machineSet := MachineSet().WithMachineSpecObjectMeta(meta).Build()
+			Expect(machineSet.Spec.Template.Spec.ObjectMeta).To(Equal(meta))
+		})
+	})
+
+	Describe("WithMachineSetSpecSelector", func() {
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.Selector.MatchLabels).To(BeZero())
+		})
+
+		It("should return the custom value when specified", func() {
+			sel := metav1.LabelSelector{
+				MatchLabels: map[string]string{"test": "label"},
+			}
+			machineSet := MachineSet().WithMachineSetSpecSelector(sel).Build()
+			Expect(machineSet.Spec.Selector).To(Equal(sel))
+		})
+	})
+
+	Describe("WithMachineTemplateAnnotations", func() {
+		It("should return the custom value when specified", func() {
+			annotations := map[string]string{"key": "value"}
+			machineSet := MachineSet().WithMachineTemplateAnnotations(annotations).Build()
+			Expect(machineSet.Spec.Template.ObjectMeta.Annotations).To(Equal(annotations))
+		})
+
+		It("should return nil when specified as such", func() {
+			machineSet := MachineSet().WithMachineTemplateAnnotations(nil).Build()
+			Expect(machineSet.Spec.Template.ObjectMeta.Annotations).To(BeNil())
+		})
+
+		It("should return nil when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.Template.ObjectMeta.Annotations).To(BeNil())
+		})
+	})
+
+	Describe("WithMachineTemplateLabel", func() {
+		It("should return the custom value when specified", func() {
+			machineSet := MachineSet().WithMachineTemplateLabel("key", "value").Build()
+			Expect(machineSet.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("key", "value"))
+		})
+	})
+
+	Describe("WithMachineTemplateLabels", func() {
+		It("should return the custom value when specified", func() {
+			labels := map[string]string{"key1": "value1", "key2": "value2"}
+			machineSet := MachineSet().WithMachineTemplateLabels(labels).Build()
+			Expect(machineSet.Spec.Template.ObjectMeta.Labels).To(Equal(labels))
+		})
+
+		It("should return nil when specified as such", func() {
+			machineSet := MachineSet().WithMachineTemplateLabels(nil).Build()
+			Expect(machineSet.Spec.Template.ObjectMeta.Labels).To(BeNil())
+		})
+
+		It("should return nil when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.Template.ObjectMeta.Labels).To(BeNil())
+		})
+	})
+
+	Describe("WithMinReadySeconds", func() {
+		It("should return the custom value when specified", func() {
+			minReadySeconds := int32(30)
+			machineSet := MachineSet().WithMinReadySeconds(minReadySeconds).Build()
+			Expect(machineSet.Spec.MinReadySeconds).To(Equal(minReadySeconds))
+		})
+	})
+
+	Describe("WithName", func() {
+		It("should return the custom value when specified", func() {
+			name := "test-machineset"
+			machineSet := MachineSet().WithName(name).Build()
+			Expect(machineSet.Name).To(Equal(name))
+		})
+	})
+
+	Describe("WithNamespace", func() {
+		It("should return the custom value when specified", func() {
+			namespace := "test-namespace"
+			machineSet := MachineSet().WithNamespace(namespace).Build()
+			Expect(machineSet.Namespace).To(Equal(namespace))
+		})
+	})
+
+	Describe("WithProviderSpec", func() {
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.Template.Spec.ProviderSpec).To(Not(BeNil()))
+		})
+
+		It("should return the custom value when specified", func() {
+			providerSpec := machinev1beta1.ProviderSpec{
+				Value: &runtime.RawExtension{Raw: []byte(`{"key":"value"}`)},
+			}
+			machineSet := MachineSet().WithProviderSpec(providerSpec).Build()
+			Expect(machineSet.Spec.Template.Spec.ProviderSpec).To(Equal(providerSpec))
+		})
+	})
+
+	Describe("WithProviderSpecBuilder", func() {
+		It("should return the custom value when specified", func() {
+			providerSpecBuilder := AWSProviderSpec()
+			machineSet := MachineSet().WithProviderSpecBuilder(providerSpecBuilder).Build()
+			Expect(machineSet.Spec.Template.Spec.ProviderSpec.Value).ToNot(BeNil())
+		})
+	})
+
+	Describe("WithReplicas", func() {
+		It("should return the custom value when specified", func() {
+			replicas := int32(3)
+			machineSet := MachineSet().WithReplicas(replicas).Build()
+			Expect(*machineSet.Spec.Replicas).To(Equal(replicas))
+		})
+
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.Replicas).To(BeNil())
+		})
+	})
+
+	Describe("WithTaints", func() {
+		It("should return nil when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Spec.Template.Spec.Taints).To(BeNil())
+		})
+
+		It("should return the custom value when specified", func() {
+			taints := []corev1.Taint{{Key: "test", Value: "taint", Effect: corev1.TaintEffectNoSchedule}}
+			machineSet := MachineSet().WithTaints(taints).Build()
+			Expect(machineSet.Spec.Template.Spec.Taints).To(Equal(taints))
+		})
+	})
+
+	// Status field tests
+
+	Describe("WithAuthoritativeAPIStatus", func() {
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.AuthoritativeAPI).To(BeZero())
+		})
+
+		It("should return the custom value when specified", func() {
+			authority := machinev1beta1.MachineAuthorityMachineAPI
+			machineSet := MachineSet().WithAuthoritativeAPIStatus(authority).Build()
+			Expect(machineSet.Status.AuthoritativeAPI).To(Equal(authority))
+		})
+	})
+
+	Describe("WithAvailableReplicas", func() {
+		It("should return the custom value when specified", func() {
+			replicas := int32(3)
+			machineSet := MachineSet().WithAvailableReplicas(replicas).Build()
+			Expect(machineSet.Status.AvailableReplicas).To(Equal(replicas))
+		})
+
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.AvailableReplicas).To(BeZero())
+		})
+	})
+
+	Describe("WithConditions", func() {
+		It("should return the custom value when specified", func() {
+			conditions := []machinev1beta1.Condition{
+				{Type: "Ready", Status: corev1.ConditionTrue},
+			}
+			machineSet := MachineSet().WithConditions(conditions).Build()
+			Expect(machineSet.Status.Conditions).To(Equal(conditions))
+		})
+
+		It("should return nil when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.Conditions).To(BeNil())
+		})
+
+		It("should return nil when specified as such", func() {
+			machineSet := MachineSet().WithConditions(nil).Build()
+			Expect(machineSet.Status.Conditions).To(BeNil())
+		})
+	})
+
+	Describe("WithErrorMessage", func() {
+		It("should return the custom value when specified", func() {
+			errorMsg := "test error"
+			machineSet := MachineSet().WithErrorMessage(errorMsg).Build()
+			Expect(*machineSet.Status.ErrorMessage).To(Equal(errorMsg))
+		})
+
+		It("should return nil when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.ErrorMessage).To(BeNil())
+		})
+	})
+
+	Describe("WithErrorReason", func() {
+		It("should return the custom value when specified", func() {
+			errorReason := machinev1beta1.InvalidConfigurationMachineSetError
+			machineSet := MachineSet().WithErrorReason(errorReason).Build()
+			Expect(*machineSet.Status.ErrorReason).To(Equal(errorReason))
+		})
+
+		It("should return nil when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.ErrorReason).To(BeNil())
+		})
+	})
+
+	Describe("WithFullyLabeledReplicas", func() {
+		It("should return the custom value when specified", func() {
+			replicas := int32(2)
+			machineSet := MachineSet().WithFullyLabeledReplicas(replicas).Build()
+			Expect(machineSet.Status.FullyLabeledReplicas).To(Equal(replicas))
+		})
+
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.FullyLabeledReplicas).To(BeZero())
+		})
+	})
+
+	Describe("WithObservedGeneration", func() {
+		It("should return the custom value when specified", func() {
+			generation := int64(5)
+			machineSet := MachineSet().WithObservedGeneration(generation).Build()
+			Expect(machineSet.Status.ObservedGeneration).To(Equal(generation))
+		})
+
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.ObservedGeneration).To(BeZero())
+		})
+	})
+
+	Describe("WithReadyReplicas", func() {
+		It("should return the custom value when specified", func() {
+			replicas := int32(4)
+			machineSet := MachineSet().WithReadyReplicas(replicas).Build()
+			Expect(machineSet.Status.ReadyReplicas).To(Equal(replicas))
+		})
+
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.ReadyReplicas).To(BeZero())
+		})
+	})
+
+	Describe("WithReplicasStatus", func() {
+		It("should return the custom value when specified", func() {
+			replicas := int32(5)
+			machineSet := MachineSet().WithReplicasStatus(replicas).Build()
+			Expect(machineSet.Status.Replicas).To(Equal(replicas))
+		})
+
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.Replicas).To(BeZero())
+		})
+	})
+
+	Describe("WithSynchronizedGeneration", func() {
+		It("should return the custom value when specified", func() {
+			generation := int64(3)
+			machineSet := MachineSet().WithSynchronizedGeneration(generation).Build()
+			Expect(machineSet.Status.SynchronizedGeneration).To(Equal(generation))
+		})
+
+		It("should return the default value when not specified", func() {
+			machineSet := MachineSet().Build()
+			Expect(machineSet.Status.SynchronizedGeneration).To(BeZero())
+		})
+	})
+})

--- a/testutils/resourcebuilder/machine/v1beta1/suite_test.go
+++ b/testutils/resourcebuilder/machine/v1beta1/suite_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1beta1
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1Beta1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "v1beta1 Suite")
+}


### PR DESCRIPTION
extend fields of resourcebuilder to allow for more flexibility for the following:

- testutils: resourcebuilder: machinev1beta1.AWSProviderSpec extend fields
- testutils: resourcebuilder: machinev1beta1.Machine extend fields
- testutils: resourcebuilder: machinev1beta1.MachineSet extend fields

**Testing**:

To prove this doesn't break existing use cases I ran cluster-control-plane-machine-set-operator unit tests successfully.
```
Ginkgo ran 11 suites in 5m30.502007958s
Test Suite Passed
```