### PR TITLE
OCPCLOUD-2749: resourcebuilder: add ability to set MAPI objects ownerReferences

### DIFF
--- a/testutils/resourcebuilder/machine/v1beta1/machine.go
+++ b/testutils/resourcebuilder/machine/v1beta1/machine.go
@@ -42,6 +42,7 @@ type MachineBuilder struct {
 	machineSpecObjectMeta machinev1beta1.ObjectMeta
 	name                  string
 	namespace             string
+	ownerReferences       []metav1.OwnerReference
 	providerID            **string
 	providerSpecBuilder   *resourcebuilder.RawExtensionBuilder
 	providerSpec          *machinev1beta1.ProviderSpec
@@ -71,6 +72,7 @@ func (m MachineBuilder) Build() *machinev1beta1.Machine {
 			Labels:            m.labels,
 			Name:              m.name,
 			Namespace:         m.namespace,
+			OwnerReferences:   m.ownerReferences,
 		},
 		Spec: coalesceMachineSpec(m.machineSpec, machinev1beta1.MachineSpec{
 			AuthoritativeAPI: m.authoritativeAPI,
@@ -191,6 +193,12 @@ func (m MachineBuilder) WithName(name string) MachineBuilder {
 // WithNamespace sets the namespace for the machine builder.
 func (m MachineBuilder) WithNamespace(namespace string) MachineBuilder {
 	m.namespace = namespace
+	return m
+}
+
+// WithOwnerReferences sets the OwnerReferences for the machine builder.
+func (m MachineBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) MachineBuilder {
+	m.ownerReferences = ownerRefs
 	return m
 }
 

--- a/testutils/resourcebuilder/machine/v1beta1/machine_test.go
+++ b/testutils/resourcebuilder/machine/v1beta1/machine_test.go
@@ -184,6 +184,21 @@ var _ = Describe("Machine", func() {
 		})
 	})
 
+	Describe("WithOwnerReferences", func() {
+		It("should return the custom value when specified", func() {
+			ownerRefs := []metav1.OwnerReference{
+				{
+					APIVersion: "machine.openshift.io/v1beta1",
+					Kind:       "MachineSet",
+					Name:       "parent-ms",
+					UID:        "12345",
+				},
+			}
+			machine := Machine().WithOwnerReferences(ownerRefs).Build()
+			Expect(machine.OwnerReferences).To(Equal(ownerRefs))
+		})
+	})
+
 	Describe("WithProviderID", func() {
 		It("should return nil when not specified", func() {
 			machine := Machine().Build()

--- a/testutils/resourcebuilder/machine/v1beta1/machineset.go
+++ b/testutils/resourcebuilder/machine/v1beta1/machineset.go
@@ -51,6 +51,7 @@ type MachineSetBuilder struct {
 	minReadySeconds            int32
 	name                       string
 	namespace                  string
+	ownerReferences            []metav1.OwnerReference
 	providerSpec               *machinev1beta1.ProviderSpec
 	providerSpecBuilder        *resourcebuilder.RawExtensionBuilder
 	replicas                   *int32
@@ -80,6 +81,7 @@ func (m MachineSetBuilder) Build() *machinev1beta1.MachineSet {
 			Labels:            m.labels,
 			Name:              m.name,
 			Namespace:         m.namespace,
+			OwnerReferences:   m.ownerReferences,
 		},
 		Spec: machinev1beta1.MachineSetSpec{
 			AuthoritativeAPI: m.authoritativeAPI,
@@ -251,6 +253,12 @@ func (m MachineSetBuilder) WithName(name string) MachineSetBuilder {
 // WithNamespace sets the namespace for the machineSet builder.
 func (m MachineSetBuilder) WithNamespace(namespace string) MachineSetBuilder {
 	m.namespace = namespace
+	return m
+}
+
+// WithOwnerReferences sets the OwnerReferences for the machineSet builder.
+func (m MachineSetBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) MachineSetBuilder {
+	m.ownerReferences = ownerRefs
 	return m
 }
 

--- a/testutils/resourcebuilder/machine/v1beta1/machineset_test.go
+++ b/testutils/resourcebuilder/machine/v1beta1/machineset_test.go
@@ -256,6 +256,21 @@ var _ = Describe("MachineSet", func() {
 		})
 	})
 
+	Describe("WithOwnerReferences", func() {
+		It("should return the custom value when specified", func() {
+			ownerRefs := []metav1.OwnerReference{
+				{
+					APIVersion: "custom.a/v1beta1",
+					Kind:       "Custom",
+					Name:       "parent",
+					UID:        "12345",
+				},
+			}
+			machineSet := MachineSet().WithOwnerReferences(ownerRefs).Build()
+			Expect(machineSet.OwnerReferences).To(Equal(ownerRefs))
+		})
+	})
+
 	Describe("WithProviderSpec", func() {
 		It("should return the default value when not specified", func() {
 			machineSet := MachineSet().Build()


### PR DESCRIPTION
add the ability to set MAPI objects ownerReferences, so we can use this in tests.