### PR TITLE
OCPQE-26161,OCPBUGS-46552: Update labels to distinguish different tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,11 @@ build-e2e:
 
 .PHONY: test-e2e
 test-e2e: ## Run openshift specific e2e test
-	hack/ci-integration.sh $(GINKGO_ARGS) --label-filter='!periodic' -p
+	hack/ci-integration.sh $(GINKGO_ARGS) --label-filter='!periodic&&!qe-only' -p
 
 .PHONY: test-e2e-periodic
 test-e2e-periodic: ## Run openshift specific periodic e2e test
-	hack/ci-integration.sh $(GINKGO_ARGS) --label-filter=periodic -p
+	hack/ci-integration.sh $(GINKGO_ARGS) --label-filter='periodic&&!qe-only' -p
 
 .PHONY: help
 help:

--- a/pkg/autoscaler/autoscaler.go
+++ b/pkg/autoscaler/autoscaler.go
@@ -110,7 +110,7 @@ func machineAutoscalerResource(targetMachineSet *machinev1.MachineSet, minReplic
 	}
 }
 
-var _ = Describe("Autoscaler should", framework.LabelAutoscaler, Serial, func() {
+var _ = Describe("Autoscaler should", framework.LabelAutoscaler, framework.LabelDisruptive, Serial, func() {
 
 	var workloadMemRequest resource.Quantity
 	var client runtimeclient.Client

--- a/pkg/framework/ginkgo-labels.go
+++ b/pkg/framework/ginkgo-labels.go
@@ -3,14 +3,36 @@ package framework
 import "github.com/onsi/ginkgo/v2"
 
 var (
-	LabelCAPI                  = ginkgo.Label("capi")
-	LabelDisruptive            = ginkgo.Label("disruptive")
-	LabelAutoscaler            = ginkgo.Label("autoscaler")
-	LabelOperators             = ginkgo.Label("operators")
-	LabelPeriodic              = ginkgo.Label("periodic")
-	LabelSpot                  = ginkgo.Label("spot-instances")
-	LabelMachines              = ginkgo.Label("machines")
-	LabelMachineHealthChecks   = ginkgo.Label("machine-health-checks")
-	LabelCloudProviderSpecific = ginkgo.Label("cloud-provider-specific")
-	LabelProviderAWS           = ginkgo.Label("AWS")
+	// LabelAutoscaler applies to tests related to the cluster autoscaler functionality.
+	LabelAutoscaler = ginkgo.Label("autoscaler")
+
+	// LabelCAPI applies to tests related to Cluster API (CAPI) functionality.
+	LabelCAPI = ginkgo.Label("capi")
+
+	// LabelCCM applies to tests related to the Cloud Controller Manager (CCM).
+	LabelCCM = ginkgo.Label("ccm")
+
+	// LabelDevOnly indicates that the test can run in dev account only.
+	LabelDevOnly = ginkgo.Label("dev-only")
+
+	// LabelDisruptive marks tests that are disruptive in nature and may affect cluster stability.
+	LabelDisruptive = ginkgo.Label("disruptive")
+
+	// LabelLEVEL0 indicates that the test is a basic or critical test, if failed then block release.
+	LabelLEVEL0 = ginkgo.Label("LEVEL0")
+
+	// LabelMachineApprover applies to tests for the machine approver functionality.
+	LabelMachineApprover = ginkgo.Label("machine-approver")
+
+	// LabelMachineHealthCheck applies to tests for Machine Health Checks (MHC) functionality.
+	LabelMachineHealthCheck = ginkgo.Label("machine-health-check")
+
+	// LabelMAPI applies to tests related to the Machine API (MAPI).
+	LabelMAPI = ginkgo.Label("mapi")
+
+	// LabelPeriodic marks tests that are meant to run periodically.
+	LabelPeriodic = ginkgo.Label("periodic")
+
+	// LabelQEOnly indicates that the test can run in qe account only.
+	LabelQEOnly = ginkgo.Label("qe-only")
 )

--- a/pkg/infra/infra.go
+++ b/pkg/infra/infra.go
@@ -147,7 +147,7 @@ func deleteObjects(client runtimeclient.Client, delObjects map[string]runtimecli
 	return nil
 }
 
-var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
+var _ = Describe("Managed cluster should", framework.LabelMAPI, func() {
 	var client runtimeclient.Client
 	var ctx context.Context
 	var machineSet *machinev1.MachineSet
@@ -186,7 +186,7 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 		}
 	})
 
-	When("machineset has one replica", func() {
+	When("machineset has one replica", framework.LabelDisruptive, func() {
 		BeforeEach(func() {
 			var err error
 			machineSetParams = framework.BuildMachineSetParams(ctx, client, 1)
@@ -266,7 +266,7 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 
 	})
 
-	When("machineset has 2 replicas", func() {
+	When("machineset has 2 replicas", framework.LabelDisruptive, func() {
 		BeforeEach(func() {
 			var err error
 			machineSetParams = framework.BuildMachineSetParams(ctx, client, 2)
@@ -280,7 +280,7 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 
 		// Machines required for test: 2
 		// Reason: We want to test that all machines get replaced when we delete them.
-		It("recover from deleted worker machines", func() {
+		It("recover from deleted worker machines", framework.LabelLEVEL0, func() {
 			selector := machineSet.Spec.Selector
 			machines, err := framework.GetMachines(ctx, client, &selector)
 			Expect(err).ToNot(HaveOccurred(), "Listing Machines should succeed")
@@ -295,7 +295,7 @@ var _ = Describe("Managed cluster should", framework.LabelMachines, func() {
 
 		// Machines required for test: 4
 		// Reason: MachineSet scales 2->0 and MachineSet2 scales 0->2. Changing to scaling 1->0 and 0->1 might not test this thoroughly.
-		It("grow and decrease when scaling different machineSets simultaneously", framework.LabelPeriodic, func() {
+		It("grow and decrease when scaling different machineSets simultaneously", framework.LabelPeriodic, framework.LabelLEVEL0, func() {
 			By("Creating a second MachineSet") // Machineset 1 can start with 1 replica
 			machineSetParams := framework.BuildMachineSetParams(ctx, client, 0)
 			machineSet2, err := framework.CreateMachineSet(client, machineSetParams)

--- a/pkg/infra/lifecyclehooks.go
+++ b/pkg/infra/lifecyclehooks.go
@@ -29,7 +29,7 @@ const (
 	pollingInterval                   = 3 * time.Second
 )
 
-var _ = Describe("Lifecycle Hooks should", framework.LabelMachines, func() {
+var _ = Describe("Lifecycle Hooks should", framework.LabelMAPI, framework.LabelDisruptive, func() {
 	var client runtimeclient.Client
 	var machineSet *machinev1.MachineSet
 	var workload *batchv1.Job

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -38,7 +38,7 @@ const (
 	spotMachineSetMaxProvisioningRetryCount = 3
 )
 
-var _ = Describe("Running on Spot", framework.LabelMachines, framework.LabelSpot, func() {
+var _ = Describe("Running on Spot", framework.LabelMAPI, framework.LabelDisruptive, func() {
 	var ctx = context.Background()
 
 	var client runtimeclient.Client

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -22,7 +22,7 @@ import (
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework/gatherer"
 )
 
-var _ = Describe("Webhooks", framework.LabelMachines, func() {
+var _ = Describe("Webhooks", framework.LabelMAPI, framework.LabelDisruptive, func() {
 	var client runtimeclient.Client
 	var platform configv1.PlatformType
 	var machineSetParams framework.MachineSetParams

--- a/pkg/machinehealthcheck/machinehealthcheck.go
+++ b/pkg/machinehealthcheck/machinehealthcheck.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework/gatherer"
 )
 
-var _ = Describe("MachineHealthCheck", framework.LabelMachineHealthChecks, func() {
+var _ = Describe("MachineHealthCheck", framework.LabelMachineHealthCheck, framework.LabelDisruptive, func() {
 	var client client.Client
 	var ctx context.Context
 

--- a/pkg/operators/cluster-autoscaler-operator.go
+++ b/pkg/operators/cluster-autoscaler-operator.go
@@ -18,7 +18,7 @@ import (
 	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework/gatherer"
 )
 
-var _ = Describe("Cluster autoscaler operator should", framework.LabelOperators, framework.LabelAutoscaler, func() {
+var _ = Describe("Cluster autoscaler operator should", framework.LabelAutoscaler, func() {
 	var client runtimeclient.Client
 	var ctx context.Context
 	var gatherer *gatherer.StateGatherer
@@ -86,7 +86,7 @@ var _ = Describe("Cluster autoscaler operator should", framework.LabelOperators,
 	})
 })
 
-var _ = Describe("Cluster autoscaler operator deployment should", framework.LabelOperators, framework.LabelAutoscaler, func() {
+var _ = Describe("Cluster autoscaler operator deployment should", framework.LabelAutoscaler, framework.LabelLEVEL0, func() {
 	It("be available", func() {
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred(), "Failed to load client")
@@ -97,7 +97,7 @@ var _ = Describe("Cluster autoscaler operator deployment should", framework.Labe
 	})
 })
 
-var _ = Describe("Cluster autoscaler cluster operator status should", framework.LabelOperators, framework.LabelAutoscaler, func() {
+var _ = Describe("Cluster autoscaler cluster operator status should", framework.LabelAutoscaler, framework.LabelLEVEL0, func() {
 	It("be available", func() {
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred(), "Failed to load client")

--- a/pkg/operators/cluster-machine-approver.go
+++ b/pkg/operators/cluster-machine-approver.go
@@ -13,7 +13,7 @@ const (
 	cmaNamespace       = "openshift-cluster-machine-approver"
 )
 
-var _ = Describe("Cluster Machine Approver deployment", framework.LabelOperators, func() {
+var _ = Describe("Cluster Machine Approver deployment", framework.LabelMachineApprover, framework.LabelLEVEL0, func() {
 	It("should be available", func() {
 		ctx := framework.GetContext()
 
@@ -25,7 +25,7 @@ var _ = Describe("Cluster Machine Approver deployment", framework.LabelOperators
 	})
 })
 
-var _ = Describe("Cluster Machine Approver Cluster Operator Status", framework.LabelOperators, func() {
+var _ = Describe("Cluster Machine Approver Cluster Operator Status", framework.LabelMachineApprover, framework.LabelLEVEL0, func() {
 	It("should be available", func() {
 		client, err := framework.LoadClient()
 		Expect(err).NotTo(HaveOccurred(), "Failed to load client")

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -24,7 +24,7 @@ var (
 
 var _ = Describe(
 	"Machine API operator deployment should",
-	framework.LabelDisruptive, framework.LabelOperators, framework.LabelMachines,
+	framework.LabelMAPI,
 	Serial,
 	func() {
 		var gatherer *gatherer.StateGatherer
@@ -42,7 +42,7 @@ var _ = Describe(
 			}
 		})
 
-		It("be available", func() {
+		It("be available", framework.LabelLEVEL0, func() {
 			ctx := framework.GetContext()
 			client, err := framework.LoadClient()
 			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
@@ -50,7 +50,7 @@ var _ = Describe(
 				fmt.Sprintf("Failed to wait for %s Deployment to become available", maoDeployment))
 		})
 
-		It("reconcile controllers deployment", func() {
+		It("reconcile controllers deployment", framework.LabelDisruptive, func() {
 			ctx := framework.GetContext()
 			client, err := framework.LoadClient()
 			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
@@ -75,7 +75,7 @@ var _ = Describe(
 				fmt.Sprintf("Failed verifying %s Deployment spec has been reconciled", maoManagedDeployment))
 		})
 
-		It("maintains deployment spec", func() {
+		It("maintains deployment spec", framework.LabelDisruptive, func() {
 			ctx := framework.GetContext()
 			client, err := framework.LoadClient()
 			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
@@ -217,7 +217,7 @@ var _ = Describe(
 			}
 		})
 
-		It("maintains spec after validating webhook configuration change and preserve caBundle", func() {
+		It("maintains spec after validating webhook configuration change and preserve caBundle", framework.LabelDisruptive, func() {
 			client, err := framework.LoadClient()
 			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
 
@@ -251,8 +251,8 @@ var _ = Describe(
 	})
 
 var _ = Describe(
-	"Machine API cluster operator status should", framework.LabelOperators, framework.LabelMachines, func() {
-		It("be available", func() {
+	"Machine API cluster operator status should", framework.LabelMAPI, func() {
+		It("be available", framework.LabelLEVEL0, func() {
 			ctx := framework.GetContext()
 
 			client, err := framework.LoadClient()
@@ -265,7 +265,7 @@ var _ = Describe(
 
 var _ = Describe(
 	"When cluster-wide proxy is configured, Machine API cluster operator should ",
-	framework.LabelDisruptive, framework.LabelOperators, framework.LabelPeriodic, framework.LabelMachines,
+	framework.LabelDisruptive, framework.LabelPeriodic, framework.LabelMAPI,
 	Serial,
 	func() {
 		var gatherer *gatherer.StateGatherer

--- a/pkg/providers/aws.go
+++ b/pkg/providers/aws.go
@@ -64,7 +64,7 @@ func createAWSClient(oc *gatherer.CLI) *framework.AwsClient {
 	return aClient
 }
 
-var _ = Describe("MetadataServiceOptions", framework.LabelCloudProviderSpecific, framework.LabelProviderAWS, func() {
+var _ = Describe("MetadataServiceOptions", framework.LabelDisruptive, framework.LabelMAPI, func() {
 	var client runtimeclient.Client
 	var clientset *kubernetes.Clientset
 
@@ -197,7 +197,7 @@ var _ = Describe("MetadataServiceOptions", framework.LabelCloudProviderSpecific,
 	})
 })
 
-var _ = Describe("CapacityReservationID", framework.LabelCloudProviderSpecific, framework.LabelProviderAWS, func() {
+var _ = Describe("CapacityReservationID", framework.LabelDisruptive, framework.LabelMAPI, func() {
 	var client runtimeclient.Client
 	var gatherer *gatherer.StateGatherer
 	var ctx context.Context


### PR DESCRIPTION
Update labels based on [doc](https://docs.google.com/document/d/1bMY03y2L7IFd2tYYo2RJNoX1ONPh88U2GslkFXYw8b8/edit?tab=t.0#heading=h.z2f5gniht7oe ) 

- QE run test in 2 jobs, one is non-disruptive, one is disruptive, so added disruptive labels to some cases to make sure these cases are not run in parallel.
- In order to select feature related cases in different repos, added capi/mapi/autoscaler/machine-health-checks/machine-approver/ccm labels.
- Added qe-only/dev-only label to make sure some cases can only run in qe or dev account.
- I didn't update Makefile to `LEVEL0&&!qe-only` as now only few LEVEL0 cases, and we have a total of 41 cases in repo, so I think keep the status quo is ok, in future we have more cases, then we change it to run only LEVEL0. If you think it's better to change to LEVEL0, I'm also ok with that. 

@JoelSpeed @shellyyang1989 @huali9 @miyadav PTAL