### PR TITLE
Disable capacity reservation test until further notice

### DIFF
--- a/pkg/providers/aws.go
+++ b/pkg/providers/aws.go
@@ -267,7 +267,9 @@ var _ = Describe("CapacityReservationID", framework.LabelCloudProviderSpecific, 
 	})
 
 	// Machines required for test: 1
-	It("machine should get Running with active capacityReservationId", func() {
+	// This is marked as pending until we resolve the fact that we cannot dynamically create capacity reservations.
+	// See https://redhat-internal.slack.com/archives/CBUT43E94/p1732621241891359
+	PIt("machine should get Running with active capacityReservationId", func() {
 		By("Get instanceType and availabilityZone from the first worker MachineSet")
 		workers, err := framework.GetWorkerMachineSets(ctx, client)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Based on https://redhat-internal.slack.com/archives/CBUT43E94/p1732621241891359, PGE have blocked us from being able to create capacity reservations on the fly. So for now, we need to disable this to unblock CI across the board.

CC @huali9 I think this may impact your QE env tests, but I'm not sure how to make this skip on one env, but not the other.
Do you know if there's a flag somewhere that we could use within the test suite to know that we are on the QE env?