### PR TITLE
OCPQE-27644: upd75396

### DIFF
--- a/pkg/framework/aws_client.go
+++ b/pkg/framework/aws_client.go
@@ -146,6 +146,31 @@ func (akms *AwsKmsClient) DescribeKeyByID(kmsKeyID string) (string, error) {
 	return result.String(), nil
 }
 
+// CreateKey create a key.
+func (akms *AwsKmsClient) CreateKey(description string) (string, error) {
+	createRes, err := akms.kmssvc.CreateKey(&kms.CreateKeyInput{
+		Description: aws.String(description),
+	})
+	if err != nil {
+		klog.Infof("Error creating key %s", err.Error())
+		return "", err
+	}
+
+	klog.Infof("key created: %s", *createRes.KeyMetadata.Arn)
+
+	return *createRes.KeyMetadata.Arn, nil
+}
+
+// DeleteKey delete a key.
+func (akms *AwsKmsClient) DeleteKey(key string) error {
+	_, err := akms.kmssvc.ScheduleKeyDeletion(&kms.ScheduleKeyDeletionInput{
+		KeyId:               aws.String(key),
+		PendingWindowInDays: aws.Int64(7),
+	})
+
+	return err
+}
+
 func timePtr(t time.Time) *time.Time {
 	return &t
 }


### PR DESCRIPTION
As the resources we pre-created are deleted, so we have to update this case to create and delete the resources in the automation, run in local passed. @sunzhaohua2 @miyadav @shellyyang1989 @JoelSpeed PTAL, thanks!
```
liuhuali@Lius-MacBook-Pro cluster-api-actuator-pkg % ./hack/ci-integration.sh -focus "should be able to run a machine using KMS keys" -v
Running Suite: Machine Suite - /Users/liuhuali/project/cluster-api-actuator-pkg/pkg
===================================================================================
Random Seed: 1735027225

Will run 1 of 45 specs
------------------------------
[BeforeSuite] 
/Users/liuhuali/project/cluster-api-actuator-pkg/pkg/e2e_test.go:63
[BeforeSuite] PASSED [1.425 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Cluster API AWS MachineSet should be able to run a machine using KMS keys [capi, disruptive, qe-only]
/Users/liuhuali/project/cluster-api-actuator-pkg/pkg/capi/aws.go:117
  STEP: Creating core cluster @ 12/24/24 16:00:59.392
  STEP: Creating AWS machine template @ 12/24/24 16:01:00.42
  STEP: Creating MachineSet "aws-machineset-75396" @ 12/24/24 16:01:05.009
  STEP: Waiting for MachineSet machines "aws-machineset-75396" to enter Running phase @ 12/24/24 16:01:05.342
  STEP: Deleting MachineSet "aws-machineset-75396" @ 12/24/24 16:04:27.466
  STEP: Waiting for MachineSet "aws-machineset-75396" to be deleted @ 12/24/24 16:04:27.809
  STEP: Deleting /aws-machine-template @ 12/24/24 16:05:59.478
• [303.623 seconds]
------------------------------
SSSSSSSSSS
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.008 seconds]
------------------------------

Ran 1 of 45 Specs in 305.050 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 44 Skipped
PASS

Ginkgo ran 1 suite in 5m34.431019966s
Test Suite Passed

```