### PR TITLE
OCPQE-27285: Fix the failures in qe ci jobs

### DIFF
--- a/hack/ci-integration.sh
+++ b/hack/ci-integration.sh
@@ -7,7 +7,7 @@ go run ./vendor/github.com/onsi/ginkgo/v2/ginkgo \
     -v \
     --timeout=115m \
     --grace-period=5m \
-    --fail-fast \
+    --fail-fast=false \
     --no-color \
     --junit-report="junit_cluster_api_actuator_pkg_e2e.xml" \
     --output-dir="${OUTPUT_DIR}" \

--- a/pkg/framework/machinesets.go
+++ b/pkg/framework/machinesets.go
@@ -77,7 +77,7 @@ func BuildPerArchMachineSetParamsList(ctx context.Context, client runtimeclient.
 	var params MachineSetParams
 
 	for _, worker := range workers {
-		if arch, err = getArchitectureFromMachineSetNodes(ctx, client, worker); err != nil {
+		if arch, err = GetArchitectureFromMachineSetNodes(ctx, client, worker); err != nil {
 			klog.Warningf("unable to get the architecture for the machine set %s: %v", worker.Name, err)
 			continue
 		}
@@ -180,7 +180,7 @@ func CreateMachineSet(c runtimeclient.Client, params MachineSetParams) (*machine
 }
 
 // BuildMachineSetParamsList creates a list of MachineSetParams based on the given machineSetParams with modified instance type.
-func BuildAlternativeMachineSetParams(machineSetParams MachineSetParams, platform configv1.PlatformType) ([]MachineSetParams, error) {
+func BuildAlternativeMachineSetParams(machineSetParams MachineSetParams, platform configv1.PlatformType, arch string) ([]MachineSetParams, error) {
 	baseMachineSetParams := machineSetParams
 	baseProviderSpec := baseMachineSetParams.ProviderSpec.DeepCopy()
 
@@ -189,7 +189,15 @@ func BuildAlternativeMachineSetParams(machineSetParams MachineSetParams, platfor
 	switch platform {
 	case configv1.AWSPlatformType:
 		// Using cheapest compute optimized instances that meet openshift minimum requirements (4 vCPU, 8GiB RAM)
-		alternativeInstanceTypes := []string{"c5.xlarge", "c5a.xlarge", "m5.xlarge"}
+		var alternativeInstanceTypes []string
+
+		switch arch {
+		case "arm64":
+			alternativeInstanceTypes = []string{"m6g.large", "t4g.nano", "t4g.micro", "m6gd.xlarge"}
+		default:
+			alternativeInstanceTypes = []string{"c5.xlarge", "c5a.xlarge", "m5.xlarge"}
+		}
+
 		for _, instanceType := range alternativeInstanceTypes {
 			updatedProviderSpec, err := updateProviderSpecAWSInstanceType(baseProviderSpec, instanceType)
 			if err != nil {
@@ -200,7 +208,15 @@ func BuildAlternativeMachineSetParams(machineSetParams MachineSetParams, platfor
 			output = append(output, baseMachineSetParams)
 		}
 	case configv1.AzurePlatformType:
-		alternativeVMSizes := []string{"Standard_F4s_v2", "Standard_D4as_v5", "Standard_D4as_v4"}
+		var alternativeVMSizes []string
+
+		switch arch {
+		case "arm64":
+			alternativeVMSizes = []string{"Standard_D2ps_v5", "Standard_D3ps_v5", "Standard_D4ps_v5"}
+		default:
+			alternativeVMSizes = []string{"Standard_F4s_v2", "Standard_D4as_v5", "Standard_D4as_v4"}
+		}
+
 		for _, VMSize := range alternativeVMSizes {
 			updatedProviderSpec, err := updateProviderSpecAzureVMSize(baseProviderSpec, VMSize)
 			if err != nil {
@@ -338,13 +354,13 @@ func GetWorkerMachineSets(ctx context.Context, client runtimeclient.Client) ([]*
 	return result, nil
 }
 
-// getArchitectureFromMachineSetNodes returns the architecture of the nodes controlled by the given machineSet's machines.
-func getArchitectureFromMachineSetNodes(ctx context.Context, client runtimeclient.Client, machineSet *machinev1.MachineSet) (string, error) {
+// GetArchitectureFromMachineSetNodes returns the architecture of the nodes controlled by the given machineSet's machines.
+func GetArchitectureFromMachineSetNodes(ctx context.Context, client runtimeclient.Client, machineSet *machinev1.MachineSet) (string, error) {
 	nodes, err := GetNodesFromMachineSet(ctx, client, machineSet)
 	if err != nil || len(nodes) == 0 {
 		klog.Warningf("error getting the machineSet's nodes or no nodes associated with %s. Using the capacity annotation", machineSet.Name)
 
-		for _, kv := range strings.Split(machineSet.Labels[labelsKey], ",") {
+		for _, kv := range strings.Split(machineSet.Annotations[labelsKey], ",") {
 			if strings.Contains(kv, "kubernetes.io/arch") {
 				return strings.Split(kv, "=")[1], nil
 			}

--- a/pkg/infra/webhooks.go
+++ b/pkg/infra/webhooks.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -112,6 +113,21 @@ var _ = Describe("Webhooks", framework.LabelMAPI, framework.LabelDisruptive, fun
 			if err != nil {
 				return err
 			}
+
+			failed := framework.FilterMachines([]*machinev1beta1.Machine{m}, framework.MachinePhaseFailed)
+			if len(failed) > 0 {
+				reason := "failureReason not present in Machine.status"
+				if m.Status.ErrorReason != nil {
+					reason = string(*m.Status.ErrorReason)
+				}
+				message := "failureMessage not present in Machine.status"
+				if m.Status.ErrorMessage != nil {
+					message = *m.Status.ErrorMessage
+				}
+				klog.Errorf("Failed machine: %s, Reason: %s, Message: %s", m.Name, reason, message)
+			}
+			Expect(len(failed)).To(Equal(0), "zero machines should be in a Failed phase")
+
 			running := framework.FilterRunningMachines([]*machinev1beta1.Machine{m})
 			if len(running) == 0 {
 				return fmt.Errorf("machine not yet running")
@@ -252,6 +268,9 @@ func minimalAzureProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.
 				OSDisk: machinev1beta1.OSDisk{
 					DiskSizeGB: fullProviderSpec.OSDisk.DiskSizeGB,
 				},
+				Vnet:                 fullProviderSpec.Vnet,
+				Subnet:               fullProviderSpec.Subnet,
+				NetworkResourceGroup: fullProviderSpec.NetworkResourceGroup,
 			},
 		},
 	}, nil
@@ -270,6 +289,11 @@ func minimalGCPProviderSpec(ps *machinev1beta1.ProviderSpec) (*machinev1beta1.Pr
 				Region:          fullProviderSpec.Region,
 				Zone:            fullProviderSpec.Zone,
 				ServiceAccounts: fullProviderSpec.ServiceAccounts,
+				NetworkInterfaces: []*machinev1beta1.GCPNetworkInterface{{
+					Network:    fullProviderSpec.NetworkInterfaces[0].Network,
+					Subnetwork: fullProviderSpec.NetworkInterfaces[0].Subnetwork,
+					ProjectID:  fullProviderSpec.NetworkInterfaces[0].ProjectID,
+				}},
 			},
 		},
 	}, nil


### PR DESCRIPTION
Fixed some issues found in qe ci jobs, @huali9 @miyadav @shellyyang1989 PTAL
- When one case failed, other cases will be interrupted, set `--fail-fast=false` so that other cases can be tested.
- Spot case failed on arm clusters, add instance types for arm clusters
- Update GetArchitectureFromMachineSetNodes to get arch from annotation
- Skip spot case on customer vpc clusters, as error:

```
termination-simulator-p862v                           1/1     Running   0              31s
$ oc logs -f termination-simulator-p862v          
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/APKINDEX.tar.gz
ERROR: https://dl-cdn.alpinelinux.org/alpine/v3.14/main: network error (check Internet connection and firewall)
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.14/main: No such file or directory
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/APKINDEX.tar.gz
```

- If machine creation failed, then stop waiting.
- Some fields are not default for customer vpc cluster, add them when creating machine from a minimal providerSpec
