### PR TITLE
Adds ability to set disks to gcp provider builder

### DIFF
--- a/testutils/resourcebuilder/machine/v1beta1/gcp_provider_spec.go
+++ b/testutils/resourcebuilder/machine/v1beta1/gcp_provider_spec.go
@@ -28,6 +28,15 @@ import (
 // GCPProviderSpec creates a new GCP machine config builder.
 func GCPProviderSpec() GCPProviderSpecBuilder {
 	return GCPProviderSpecBuilder{
+		disks: []*machinev1beta1.GCPDisk{
+			{
+				AutoDelete: true,
+				Boot:       true,
+				Image:      "projects/rhcos-cloud/global/images/rhcos-411-85-202205101201-0-gcp-x86-64",
+				SizeGB:     128,
+				Type:       "pd-ssd",
+			},
+		},
 		machineType: "n1-standard-4",
 		targetPools: []string{"target-pool-1", "target-pool-2"},
 		zone:        "us-central1-a",
@@ -36,6 +45,7 @@ func GCPProviderSpec() GCPProviderSpecBuilder {
 
 // GCPProviderSpecBuilder is used to build a GCP machine config object.
 type GCPProviderSpecBuilder struct {
+	disks       []*machinev1beta1.GCPDisk
 	machineType string
 	targetPools []string
 	zone        string
@@ -65,15 +75,7 @@ func (m GCPProviderSpecBuilder) Build() *machinev1beta1.GCPMachineProviderSpec {
 		CanIPForward: false,
 		ProjectID:    "openshift-cpms-unit-tests",
 		Region:       "us-central1",
-		Disks: []*machinev1beta1.GCPDisk{
-			{
-				AutoDelete: true,
-				Boot:       true,
-				Image:      "projects/rhcos-cloud/global/images/rhcos-411-85-202205101201-0-gcp-x86-64",
-				SizeGB:     128,
-				Type:       "pd-ssd",
-			},
-		},
+		Disks:        m.disks,
 		Tags: []string{
 			"gcp-tag-12345678",
 		},
@@ -101,6 +103,12 @@ func (m GCPProviderSpecBuilder) BuildRawExtension() *runtime.RawExtension {
 	return &runtime.RawExtension{
 		Raw: raw,
 	}
+}
+
+// WithDisks sets the disks for a machine config builder.
+func (m GCPProviderSpecBuilder) WithDisks(disks []*machinev1beta1.GCPDisk) GCPProviderSpecBuilder {
+	m.disks = disks
+	return m
 }
 
 // WithMachineType sets the machine type for the GCP machine config builder.


### PR DESCRIPTION
This change updates the gcp provider spec builder to allow setting of disks. It retains the current default.