### PR TITLE
OCPCLOUD-2792 , OCPQE-26834 - test

### DIFF
--- a/pkg/capi/misc.go
+++ b/pkg/capi/misc.go
@@ -1,0 +1,44 @@
+package capi
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ctx context.Context
+)
+
+var _ = Describe("Cluster API status values", framework.LabelCAPI, Ordered, func() {
+	BeforeAll(func() {
+		var err error
+		cl, err = framework.LoadClient()
+		Expect(err).ToNot(HaveOccurred(), "Failed to get Kubernetes client")
+		ctx = context.TODO()
+		oc, _ := framework.NewCLI()
+		framework.SkipIfNotTechPreviewNoUpgrade(oc, cl)
+	})
+
+	It("should have CoreClusterControllerAvailable condition", func() {
+		// Fetch the ClusterOperator resource
+		co := &configv1.ClusterOperator{}
+		err := cl.Get(ctx, client.ObjectKey{Name: "cluster-api"}, co)
+		Expect(err).ToNot(HaveOccurred(), "Failed to fetch cluster-api ClusterOperator")
+
+		// Check if the status contains CoreClusterControllerAvailable
+		found := false
+		for _, cond := range co.Status.Conditions {
+			if cond.Type == "CoreClusterControllerAvailable" && cond.Status == configv1.ConditionTrue {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "Expected CoreClusterControllerAvailable condition to be present and true")
+	})
+})


### PR DESCRIPTION
@sunzhaohua2 @huali9 @damdo PTAL when time permits , created this so we can add more conditions later when needed.

```
`miyadav@miyadav-thinkpadx1carbongen8:~/cluster-api-actuator-pkg$ ./hack/ci-integration.sh -focus "Cluster API status values" -v
Running Suite: Machine Suite - /home/miyadav/cluster-api-actuator-pkg/pkg
=========================================================================
Random Seed: 1741773061

Will run 1 of 60 specs
------------------------------
[BeforeSuite] 
/home/miyadav/cluster-api-actuator-pkg/pkg/e2e_test.go:68
[BeforeSuite] PASSED [1.175 seconds]
------------------------------
Cluster API status values should have CoreClusterControllerAvailable condition [capi]
/home/miyadav/cluster-api-actuator-pkg/pkg/capi/misc.go:28
• [1.501 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.004 seconds]
------------------------------

Ran 1 of 60 Specs in 2.679 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 59 Skipped
PASS

Ginkgo ran 1 suite in 10.33479328s
Test Suite Passed`
```