### PR TITLE
OCPCLOUD-2716: add ownerReference to resource builders

### DIFF
--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta1/openstackmachine.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta1/openstackmachine.go
@@ -34,10 +34,11 @@ func OpenStackMachine() OpenStackMachineBuilder {
 // OpenStackMachineBuilder is used to build out an OpenStackMachine object.
 type OpenStackMachineBuilder struct {
 	// ObjectMeta fields.
-	annotations map[string]string
-	labels      map[string]string
-	name        string
-	namespace   string
+	annotations     map[string]string
+	labels          map[string]string
+	name            string
+	namespace       string
+	ownerReferences []metav1.OwnerReference
 
 	// Spec fields.
 	additionalBlockDevices            []capov1.AdditionalBlockDevice
@@ -75,10 +76,11 @@ func (a OpenStackMachineBuilder) Build() *capov1.OpenStackMachine {
 			Kind:       "OpenStackMachine",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        a.name,
-			Namespace:   a.namespace,
-			Labels:      a.labels,
-			Annotations: a.annotations,
+			Name:            a.name,
+			Namespace:       a.namespace,
+			Labels:          a.labels,
+			Annotations:     a.annotations,
+			OwnerReferences: a.ownerReferences,
 		},
 		Spec: capov1.OpenStackMachineSpec{
 			AdditionalBlockDevices:            a.additionalBlockDevices,
@@ -135,6 +137,12 @@ func (a OpenStackMachineBuilder) WithName(name string) OpenStackMachineBuilder {
 // WithNamespace sets the namespace for the OpenStackMachine builder.
 func (a OpenStackMachineBuilder) WithNamespace(namespace string) OpenStackMachineBuilder {
 	a.namespace = namespace
+	return a
+}
+
+// WithOwnerReferences sets the OwnerReferences for the machine builder.
+func (a OpenStackMachineBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) OpenStackMachineBuilder {
+	a.ownerReferences = ownerRefs
 	return a
 }
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta1/openstackmachine_test.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta1/openstackmachine_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capov1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 )
 
@@ -41,6 +42,14 @@ var _ = Describe("OpenStackMachineBuilder", func() {
 			annotations := map[string]string{"key": "value"}
 			openstackMachine := OpenStackMachine().WithAnnotations(annotations).Build()
 			Expect(openstackMachine.Annotations).To(Equal(annotations))
+		})
+	})
+
+	Describe("WithOwnerReferences", func() {
+		It("should return the custom value when specified", func() {
+			ownerReferences := []metav1.OwnerReference{{Name: "machine"}}
+			openstackMachine := OpenStackMachine().WithOwnerReferences(ownerReferences).Build()
+			Expect(openstackMachine.OwnerReferences).To(Equal(ownerReferences))
 		})
 	})
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta1/openstackmachinetemplate.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta1/openstackmachinetemplate.go
@@ -37,6 +37,7 @@ type OpenStackMachineTemplateBuilder struct {
 	labels            map[string]string
 	name              string
 	namespace         string
+	ownerReference    []metav1.OwnerReference
 
 	// Spec fields.
 	additionalBlockDevices            []capov1.AdditionalBlockDevice
@@ -72,6 +73,7 @@ func (a OpenStackMachineTemplateBuilder) Build() *capov1.OpenStackMachineTemplat
 			Labels:            a.labels,
 			Name:              a.name,
 			Namespace:         a.namespace,
+			OwnerReferences:   a.ownerReference,
 		},
 		Spec: capov1.OpenStackMachineTemplateSpec{
 			Template: capov1.OpenStackMachineTemplateResource{
@@ -141,6 +143,12 @@ func (a OpenStackMachineTemplateBuilder) WithName(name string) OpenStackMachineT
 // WithNamespace sets the namespace for the OpenStackMachineTemplate builder.
 func (a OpenStackMachineTemplateBuilder) WithNamespace(namespace string) OpenStackMachineTemplateBuilder {
 	a.namespace = namespace
+	return a
+}
+
+// WithOwnerReferences sets the OwnerReferences for the OpenStackMachineTemplate builder.
+func (a OpenStackMachineTemplateBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) OpenStackMachineTemplateBuilder {
+	a.ownerReference = ownerRefs
 	return a
 }
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta1/openstackmachinetemplate_test.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta1/openstackmachinetemplate_test.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	capov1 "sigs.k8s.io/cluster-api-provider-openstack/api/v1beta1"
 )
@@ -40,6 +41,14 @@ var _ = Describe("OpenStackMachineTemplateBuilder", func() {
 			annotations := map[string]string{"key": "value"}
 			openstackMachineTemplate := OpenStackMachineTemplate().WithAnnotations(annotations).Build()
 			Expect(openstackMachineTemplate.Annotations).To(Equal(annotations))
+		})
+	})
+
+	Describe("WithOwnerReferences", func() {
+		It("should return the custom value when specified", func() {
+			ownerReferences := []metav1.OwnerReference{{Name: "cluster"}}
+			openstackMachineTemplate := OpenStackMachineTemplate().WithOwnerReferences(ownerReferences).Build()
+			Expect(openstackMachineTemplate.OwnerReferences).To(Equal(ownerReferences))
 		})
 	})
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine.go
@@ -30,10 +30,11 @@ func AWSMachine() AWSMachineBuilder {
 // AWSMachineBuilder is used to build out an AWSMachine object.
 type AWSMachineBuilder struct {
 	// ObjectMeta fields.
-	annotations map[string]string
-	labels      map[string]string
-	name        string
-	namespace   string
+	annotations     map[string]string
+	labels          map[string]string
+	name            string
+	namespace       string
+	ownerReferences []metav1.OwnerReference
 
 	// Spec fields.
 	additionalSecurityGroups []capav1.AWSResourceReference
@@ -83,10 +84,11 @@ func (a AWSMachineBuilder) Build() *capav1.AWSMachine {
 			Kind:       "AWSMachine",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        a.name,
-			Namespace:   a.namespace,
-			Labels:      a.labels,
-			Annotations: a.annotations,
+			Name:            a.name,
+			Namespace:       a.namespace,
+			Labels:          a.labels,
+			Annotations:     a.annotations,
+			OwnerReferences: a.ownerReferences,
 		},
 		Spec: capav1.AWSMachineSpec{
 			AdditionalSecurityGroups: a.additionalSecurityGroups,
@@ -155,6 +157,12 @@ func (a AWSMachineBuilder) WithName(name string) AWSMachineBuilder {
 // WithNamespace sets the namespace for the AWSMachine builder.
 func (a AWSMachineBuilder) WithNamespace(namespace string) AWSMachineBuilder {
 	a.namespace = namespace
+	return a
+}
+
+// WithOwnerReferences sets the OwnerReferences for the machine builder.
+func (a AWSMachineBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) AWSMachineBuilder {
+	a.ownerReferences = ownerRefs
 	return a
 }
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine_test.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	capav1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -65,6 +66,14 @@ var _ = Describe("AWSMachineBuilder", func() {
 		It("should return the custom value when specified", func() {
 			awsMachine := AWSMachine().WithNamespace("ns-test-5").Build()
 			Expect(awsMachine.Namespace).To(Equal("ns-test-5"))
+		})
+	})
+
+	Describe("WithOwnerReferences", func() {
+		It("should return the custom value when specified", func() {
+			ownerRefs := []metav1.OwnerReference{{Name: "machineName"}}
+			awsMachine := AWSMachine().WithOwnerReferences(ownerRefs).Build()
+			Expect(awsMachine.OwnerReferences).To(Equal(ownerRefs))
 		})
 	})
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate.go
@@ -37,6 +37,7 @@ type AWSMachineTemplateBuilder struct {
 	labels            map[string]string
 	name              string
 	namespace         string
+	ownerReferences   []metav1.OwnerReference
 
 	// Spec fields.
 	additionalSecurityGroups []capav1.AWSResourceReference
@@ -87,6 +88,7 @@ func (a AWSMachineTemplateBuilder) Build() *capav1.AWSMachineTemplate {
 			Labels:            a.labels,
 			Name:              a.name,
 			Namespace:         a.namespace,
+			OwnerReferences:   a.ownerReferences,
 		},
 		Spec: capav1.AWSMachineTemplateSpec{
 			Template: capav1.AWSMachineTemplateResource{
@@ -171,6 +173,12 @@ func (a AWSMachineTemplateBuilder) WithName(name string) AWSMachineTemplateBuild
 // WithNamespace sets the namespace for the AWSMachineTemplate builder.
 func (a AWSMachineTemplateBuilder) WithNamespace(namespace string) AWSMachineTemplateBuilder {
 	a.namespace = namespace
+	return a
+}
+
+// WithOwnerReferences sets the OwnerReferences for the AWSMachineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) AWSMachineTemplateBuilder {
+	a.ownerReferences = ownerRefs
 	return a
 }
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate_test.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate_test.go
@@ -92,6 +92,14 @@ var _ = Describe("AWSMachineTemplate", func() {
 		})
 	})
 
+	Describe("WithOwnerReferences", func() {
+		It("should return the custom value when specified", func() {
+			ownerReferences := []metav1.OwnerReference{{Name: "cluster"}}
+			awsMachineTemplate := AWSMachineTemplate().WithOwnerReferences(ownerReferences).Build()
+			Expect(awsMachineTemplate.OwnerReferences).To(Equal(ownerReferences))
+		})
+	})
+
 	// Spec fields.
 
 	Describe("WithAdditionalSecurityGroups", func() {

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/powervsmachine.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/powervsmachine.go
@@ -32,10 +32,11 @@ func PowerVSMachine() PowerVSMachineBuilder {
 // PowerVSMachineBuilder is used to build out an PowerVSMachine object.
 type PowerVSMachineBuilder struct {
 	// ObjectMeta fields.
-	annotations map[string]string
-	labels      map[string]string
-	name        string
-	namespace   string
+	annotations     map[string]string
+	labels          map[string]string
+	name            string
+	namespace       string
+	ownerReferences []metav1.OwnerReference
 
 	// Spec fields.
 	image           *capibmv1.IBMPowerVSResourceReference
@@ -66,10 +67,11 @@ func (p PowerVSMachineBuilder) Build() *capibmv1.IBMPowerVSMachine {
 			APIVersion: capibmv1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        p.name,
-			Namespace:   p.namespace,
-			Labels:      p.labels,
-			Annotations: p.annotations,
+			Name:            p.name,
+			Namespace:       p.namespace,
+			Labels:          p.labels,
+			Annotations:     p.annotations,
+			OwnerReferences: p.ownerReferences,
 		},
 		Spec: capibmv1.IBMPowerVSMachineSpec{
 			ServiceInstance: p.serviceInstance,
@@ -118,6 +120,12 @@ func (p PowerVSMachineBuilder) WithName(name string) PowerVSMachineBuilder {
 // WithNamespace sets the namespace for the PowerVSMachine builder.
 func (p PowerVSMachineBuilder) WithNamespace(namespace string) PowerVSMachineBuilder {
 	p.namespace = namespace
+	return p
+}
+
+// WithOwnerReferences sets the OwnerReferences for the machine builder.
+func (p PowerVSMachineBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) PowerVSMachineBuilder {
+	p.ownerReferences = ownerRefs
 	return p
 }
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/powervsmachine_test.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/powervsmachine_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	capibmv1 "sigs.k8s.io/cluster-api-provider-ibmcloud/api/v1beta2"
@@ -67,6 +68,14 @@ var _ = Describe("PowerVSMachine", func() {
 		It("should return the custom value when specified", func() {
 			PowerVSMachine := PowerVSMachine().WithNamespace("ns-test-5").Build()
 			Expect(PowerVSMachine.Namespace).To(Equal("ns-test-5"))
+		})
+	})
+
+	Describe("WithOwnerReferences", func() {
+		It("should return the custom value when specified", func() {
+			ownerReferences := []metav1.OwnerReference{{Name: "machine"}}
+			PowerVSMachine := PowerVSMachine().WithOwnerReferences(ownerReferences).Build()
+			Expect(PowerVSMachine.OwnerReferences).To(Equal(ownerReferences))
 		})
 	})
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/powervsmachinetemplate.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/powervsmachinetemplate.go
@@ -38,6 +38,7 @@ type PowerVSMachineTemplateBuilder struct {
 	labels            map[string]string
 	name              string
 	namespace         string
+	ownerReferences   []metav1.OwnerReference
 
 	// Spec fields.
 	image           *capibmv1.IBMPowerVSResourceReference
@@ -70,6 +71,7 @@ func (p PowerVSMachineTemplateBuilder) Build() *capibmv1.IBMPowerVSMachineTempla
 			Labels:            p.labels,
 			Name:              p.name,
 			Namespace:         p.namespace,
+			OwnerReferences:   p.ownerReferences,
 		},
 		Spec: capibmv1.IBMPowerVSMachineTemplateSpec{
 			Template: capibmv1.IBMPowerVSMachineTemplateResource{
@@ -134,6 +136,12 @@ func (p PowerVSMachineTemplateBuilder) WithName(name string) PowerVSMachineTempl
 // WithNamespace sets the namespace for the PowerVSMachineTemplate builder.
 func (p PowerVSMachineTemplateBuilder) WithNamespace(namespace string) PowerVSMachineTemplateBuilder {
 	p.namespace = namespace
+	return p
+}
+
+// WithOwnerReferences sets the OwnerReferences for the PowerVSMachineTemplate builder.
+func (p PowerVSMachineTemplateBuilder) WithOwnerReferences(ownerRefs []metav1.OwnerReference) PowerVSMachineTemplateBuilder {
+	p.ownerReferences = ownerRefs
 	return p
 }
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/powervsmachinetemplate_test.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/powervsmachinetemplate_test.go
@@ -94,6 +94,14 @@ var _ = Describe("PowerVSMachineTemplate", func() {
 		})
 	})
 
+	Describe("WithOwnerReferences", func() {
+		It("should return the custom value when specified", func() {
+			ownerReferences := []metav1.OwnerReference{{Name: "cluster"}}
+			powerVSMachineTemplate := PowerVSMachineTemplate().WithOwnerReferences(ownerReferences).Build()
+			Expect(powerVSMachineTemplate.OwnerReferences).To(Equal(ownerReferences))
+		})
+	})
+
 	// Spec fields.
 
 	Describe("WithServiceInstance", func() {


### PR DESCRIPTION
Adds ownerReference to resource builders for InfraMachines and InfraMachineTemplates.