### PR TITLE
OCPCLOUD-2895: Add networkInterfaceType to AWS builders

### DIFF
--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine.go
@@ -52,6 +52,7 @@ type AWSMachineBuilder struct {
 	instanceMetadataOptions  *capav1.InstanceMetadataOptions
 	instanceType             string
 	networkInterfaces        []string
+	networkInterfaceType     capav1.NetworkInterfaceType
 	nonRootVolumes           []capav1.Volume
 	placementGroupName       string
 	placementGroupPartition  int64
@@ -106,6 +107,7 @@ func (a AWSMachineBuilder) Build() *capav1.AWSMachine {
 			InstanceMetadataOptions:  a.instanceMetadataOptions,
 			InstanceType:             a.instanceType,
 			NetworkInterfaces:        a.networkInterfaces,
+			NetworkInterfaceType:     a.networkInterfaceType,
 			NonRootVolumes:           a.nonRootVolumes,
 			PlacementGroupName:       a.placementGroupName,
 			PlacementGroupPartition:  a.placementGroupPartition,
@@ -255,6 +257,12 @@ func (a AWSMachineBuilder) WithInstanceType(instanceType string) AWSMachineBuild
 // WithNetworkInterfaces sets the networkInterfaces for the AWSMachine builder.
 func (a AWSMachineBuilder) WithNetworkInterfaces(networkInterfaces []string) AWSMachineBuilder {
 	a.networkInterfaces = networkInterfaces
+	return a
+}
+
+// WithNetworkInterfaceType sets the networkInterfaceType for the AWSMachine builder.
+func (a AWSMachineBuilder) WithNetworkInterfaceType(networkInterfaceType capav1.NetworkInterfaceType) AWSMachineBuilder {
+	a.networkInterfaceType = networkInterfaceType
 	return a
 }
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine_test.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachine_test.go
@@ -197,6 +197,14 @@ var _ = Describe("AWSMachineBuilder", func() {
 		})
 	})
 
+	Describe("WithNetworkInterfaceType", func() {
+		It("should return the custom value when specified", func() {
+			networkInterfaceType := capav1.NetworkInterfaceTypeEFAWithENAInterface
+			awsMachine := AWSMachine().WithNetworkInterfaceType(networkInterfaceType).Build()
+			Expect(awsMachine.Spec.NetworkInterfaceType).To(Equal(networkInterfaceType))
+		})
+	})
+
 	Describe("WithNonRootVolumes", func() {
 		It("should return the custom value when specified", func() {
 			volumes := []capav1.Volume{{DeviceName: "test-device", Size: 100}}

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate.go
@@ -55,6 +55,7 @@ type AWSMachineTemplateBuilder struct {
 	instanceMetadataOptions  *capav1.InstanceMetadataOptions
 	instanceType             string
 	networkInterfaces        []string
+	networkInterfaceType     capav1.NetworkInterfaceType
 	nonRootVolumes           []capav1.Volume
 	placementGroupName       string
 	placementGroupPartition  int64
@@ -108,6 +109,7 @@ func (a AWSMachineTemplateBuilder) Build() *capav1.AWSMachineTemplate {
 					InstanceMetadataOptions:  a.instanceMetadataOptions,
 					InstanceType:             a.instanceType,
 					NetworkInterfaces:        a.networkInterfaces,
+					NetworkInterfaceType:     a.networkInterfaceType,
 					NonRootVolumes:           a.nonRootVolumes,
 					PlacementGroupName:       a.placementGroupName,
 					PlacementGroupPartition:  a.placementGroupPartition,
@@ -271,6 +273,12 @@ func (a AWSMachineTemplateBuilder) WithInstanceType(instanceType string) AWSMach
 // WithNetworkInterfaces sets the networkInterfaces for the AWSMachineTemplate builder.
 func (a AWSMachineTemplateBuilder) WithNetworkInterfaces(interfaces []string) AWSMachineTemplateBuilder {
 	a.networkInterfaces = interfaces
+	return a
+}
+
+// WithNetworkInterfaceType sets the networkInterfaceType networkInterfaceType for the AWSMAchineTemplate builder.
+func (a AWSMachineTemplateBuilder) WithNetworkInterfaceType(networkInterfaceType capav1.NetworkInterfaceType) AWSMachineTemplateBuilder {
+	a.networkInterfaceType = networkInterfaceType
 	return a
 }
 

--- a/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate_test.go
+++ b/testutils/resourcebuilder/cluster-api/infrastructure/v1beta2/awsmachinetemplate_test.go
@@ -212,6 +212,14 @@ var _ = Describe("AWSMachineTemplate", func() {
 		})
 	})
 
+	Describe("WithNetworkInterfaceType", func() {
+		It("should return the custom value when specified", func() {
+			networkInterfaceType := capav1.NetworkInterfaceTypeEFAWithENAInterface
+			awsMachineTemplate := AWSMachineTemplate().WithNetworkInterfaceType(networkInterfaceType).Build()
+			Expect(awsMachineTemplate.Spec.Template.Spec.NetworkInterfaceType).To(Equal(networkInterfaceType))
+		})
+	})
+
 	Describe("WithNonRootVolumes", func() {
 		It("should return the custom value when specified", func() {
 			volumes := []capav1.Volume{{DeviceName: "test-device", Size: 100}}


### PR DESCRIPTION
Adds new field networkInterfaceType to awsMachine and awsMachineTemplate resource builders.