### PR TITLE
OCPQE-27285: azure coditionally set identity

### DIFF
--- a/pkg/capi/azure.go
+++ b/pkg/capi/azure.go
@@ -3,6 +3,7 @@ package capi
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	gotypes "github.com/onsi/ginkgo/v2/types"
@@ -206,13 +207,25 @@ func newAzureMachineTemplate(client runtimeclient.Client, mapiProviderSpec *mapi
 
 	subscriptionID := azureCredentialsSecret.Data["azure_subscription_id"]
 	azureImageID := fmt.Sprintf("/subscriptions/%s%s", subscriptionID, mapiProviderSpec.Image.ResourceID)
+
+	var (
+		identity               = azurev1.VMIdentityNone
+		userAssignedIdentities []azurev1.UserAssignedIdentity
+	)
+
+	if mi := mapiProviderSpec.ManagedIdentity; mi != "" {
+		providerID := mi
+		if !strings.HasPrefix(mi, "/subscriptions/") {
+			providerID = fmt.Sprintf("azure:///subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", subscriptionID, mapiProviderSpec.ResourceGroup, mi)
+		}
+
+		userAssignedIdentities = []azurev1.UserAssignedIdentity{{ProviderID: providerID}}
+		identity = azurev1.VMIdentityUserAssigned
+	}
+
 	azureMachineSpec := azurev1.AzureMachineSpec{
-		Identity: azurev1.VMIdentityUserAssigned,
-		UserAssignedIdentities: []azurev1.UserAssignedIdentity{
-			{
-				ProviderID: fmt.Sprintf("azure:///subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s", subscriptionID, mapiProviderSpec.ResourceGroup, mapiProviderSpec.ManagedIdentity),
-			},
-		},
+		Identity:               identity,
+		UserAssignedIdentities: userAssignedIdentities,
 		NetworkInterfaces: []azurev1.NetworkInterface{
 			{
 				PrivateIPConfigs:      1,


### PR DESCRIPTION
Same with https://github.com/openshift/cluster-capi-operator/pull/276
https://github.com/openshift/installer/pull/9538 introduced some changes in how MAPZ machines get generated.
So we need to account for it when we generate the CAPZ machine from those.
@huali9 @miyadav PTAL

```
$ ./hack/ci-integration.sh -focus "Cluster API Azure MachineSet should be able to run a machine" -v
Running Suite: Machine Suite - /Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg
=========================================================================================================
Random Seed: 1744346690

Will run 1 of 59 specs
------------------------------
[BeforeSuite] 
/Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e_test.go:68
[BeforeSuite] PASSED [1.169 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Cluster API Azure MachineSet should be able to run a machine [capi, disruptive]
/Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/capi/azure.go:74
  [SKIPPED] in [BeforeAll] - /Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/framework/framework.go:295 @ 04/11/25 12:46:48.662
S [SKIPPED] [0.925 seconds]
Cluster API Azure MachineSet [BeforeAll] should be able to run a machine [capi, disruptive]
  [BeforeAll] /Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/capi/azure.go:40
  [It] /Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/capi/azure.go:74

  [SKIPPED] FeatureSet is not TechPreviewNoUpgradec, skip it!
  In [BeforeAll] at: /Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/framework/framework.go:295 @ 04/11/25 12:46:48.662
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.007 seconds]
------------------------------

Ran 0 of 59 Specs in 2.097 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 59 Skipped
PASS

Ginkgo ran 1 suite in 1m58.583199992s
Test Suite Passed
sunzhaohua:cluster-api-actuator-pkg/ (master✗) $ export KUBECONFIG=/Users/sunzhaohua/kubeconfig/azure/kubeconfig               [12:47:06]
sunzhaohua:cluster-api-actuator-pkg/ (master✗) $ oc get node                                                                   [13:12:58]
sunzhaohua:cluster-api-actuator-pkg/ (master✗) $ ./hack/ci-integration.sh -focus "Cluster API Azure MachineSet should be able to run a machine" -v
Running Suite: Machine Suite - /Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg
=========================================================================================================
Random Seed: 1744348388

Will run 1 of 59 specs
------------------------------
[BeforeSuite] 
/Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e_test.go:68
[BeforeSuite] PASSED [1.123 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Cluster API Azure MachineSet should be able to run a machine [capi, disruptive]
/Users/sunzhaohua/go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/capi/azure.go:75
  STEP: Creating core cluster @ 04/11/25 13:13:40.149
  STEP: Creating Azure machine template @ 04/11/25 13:13:41.453
  STEP: Creating MachineSet "azure-machineset-75884" @ 04/11/25 13:13:42.698
  STEP: Waiting for MachineSet machines "azure-machineset-75884" to enter Running phase @ 04/11/25 13:13:42.977
  STEP: Deleting MachineSet "azure-machineset-75884" @ 04/11/25 13:19:25.876
  STEP: Waiting for MachineSet "azure-machineset-75884" to be deleted @ 04/11/25 13:19:26.143
  STEP: Deleting /azure-machine-template @ 04/11/25 13:19:52.977
• [374.899 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSS
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.008 seconds]
------------------------------

Ran 1 of 59 Specs in 376.024 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 58 Skipped
PASS

Ginkgo ran 1 suite in 6m44.532973183s
Test Suite Passed
```