### PR TITLE
OCPQE-29297: auto75779

### DIFF
--- a/pkg/capi/azure.go
+++ b/pkg/capi/azure.go
@@ -73,7 +73,7 @@ var _ = Describe("Cluster API Azure MachineSet", framework.LabelCAPI, framework.
 	// OCP-75884 - [CAPI] Create machineset with capi on Azure.
 	// author: zhsun@redhat.com
 	It("should be able to run a machine", func() {
-		azureMachineTemplate = newAzureMachineTemplate(client, mapiMachineSpec)
+		azureMachineTemplate = newAzureMachineTemplate(client, azureMachineTemplateName, mapiMachineSpec)
 		Expect(client.Create(ctx, azureMachineTemplate)).To(Succeed(), "Failed to create azuremachinetemplate")
 		machineSet, err = framework.CreateCAPIMachineSet(ctx, client, framework.NewCAPIMachineSetParams(
 			"azure-machineset-75884",
@@ -94,7 +94,7 @@ var _ = Describe("Cluster API Azure MachineSet", framework.LabelCAPI, framework.
 	// author: zhsun@redhat.com
 	// EncryptionAtHost feature is not enabled for dev subscription, added framework.LabelQEOnly
 	It("should be able to run a machine with host-based disk encryption", framework.LabelQEOnly, func() {
-		azureMachineTemplate = newAzureMachineTemplate(client, mapiMachineSpec)
+		azureMachineTemplate = newAzureMachineTemplate(client, azureMachineTemplateName, mapiMachineSpec)
 		azureMachineTemplate.Spec.Template.Spec.SecurityProfile = &azurev1.SecurityProfile{
 			EncryptionAtHost: ptr.To(true),
 		}
@@ -120,7 +120,7 @@ var _ = Describe("Cluster API Azure MachineSet", framework.LabelCAPI, framework.
 	// OCP-75961 - [CAPI] Enable accelerated network via MachineSets on Azure.
 	// author: zhsun@redhat.com
 	It("should be able to run a machine with accelerated network", func() {
-		azureMachineTemplate = newAzureMachineTemplate(client, mapiMachineSpec)
+		azureMachineTemplate = newAzureMachineTemplate(client, azureMachineTemplateName, mapiMachineSpec)
 		azureMachineTemplate.Spec.Template.Spec.NetworkInterfaces = []azurev1.NetworkInterface{
 			{
 				AcceleratedNetworking: ptr.To(true),
@@ -153,7 +153,7 @@ var _ = Describe("Cluster API Azure MachineSet", framework.LabelCAPI, framework.
 		if region == "northcentralus" || region == "westus" || region == "usgovtexas" {
 			Skip("Skipping this test scenario on the " + region + " region, because this region doesn't have zones")
 		}
-		azureMachineTemplate = newAzureMachineTemplate(client, mapiMachineSpec)
+		azureMachineTemplate = newAzureMachineTemplate(client, azureMachineTemplateName, mapiMachineSpec)
 		azureMachineTemplate.Spec.Template.Spec.SpotVMOptions = &azurev1.SpotVMOptions{}
 		Expect(client.Create(ctx, azureMachineTemplate)).To(Succeed(), "Failed to create azuremachinetemplate")
 		machineSet, err = framework.CreateCAPIMachineSet(ctx, client, framework.NewCAPIMachineSetParams(
@@ -189,7 +189,7 @@ func getAzureMAPIProviderSpec(client runtimeclient.Client) *mapiv1.AzureMachineP
 	return providerSpec
 }
 
-func newAzureMachineTemplate(client runtimeclient.Client, mapiProviderSpec *mapiv1.AzureMachineProviderSpec) *azurev1.AzureMachineTemplate {
+func newAzureMachineTemplate(client runtimeclient.Client, name string, mapiProviderSpec *mapiv1.AzureMachineProviderSpec) *azurev1.AzureMachineTemplate {
 	By("Creating Azure machine template")
 	Expect(mapiProviderSpec).ToNot(BeNil(), "expected the mapi ProviderSpec to not be nil")
 	Expect(mapiProviderSpec.Subnet).ToNot(BeEmpty(), "expected the mapi Subnet to not be empty")
@@ -251,7 +251,7 @@ func newAzureMachineTemplate(client runtimeclient.Client, mapiProviderSpec *mapi
 
 	azureMachineTemplate := &azurev1.AzureMachineTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      azureMachineTemplateName,
+			Name:      name,
 			Namespace: framework.ClusterAPINamespace,
 		},
 		Spec: azurev1.AzureMachineTemplateSpec{

--- a/pkg/capi/core.go
+++ b/pkg/capi/core.go
@@ -1,0 +1,149 @@
+package capi
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	gotypes "github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	mapiv1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	awsv1 "sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	azurev1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	gcpv1 "sigs.k8s.io/cluster-api-provider-gcp/api/v1beta1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+)
+
+var _ = Describe("Cluster API MachineSet", framework.LabelCAPI, framework.LabelDisruptive, Ordered, func() {
+	var awsMachineTemplate *awsv1.AWSMachineTemplate
+	var azureMachineTemplate *azurev1.AzureMachineTemplate
+	var gcpMachineTemplate *gcpv1.GCPMachineTemplate
+	var awsMapiMachineSpec *mapiv1.AWSMachineProviderConfig
+	var azureMapiMachineSpec *mapiv1.AzureMachineProviderSpec
+	var gcpMapiMachineSpec *mapiv1.GCPMachineProviderSpec
+	var machineSet *clusterv1.MachineSet
+	var client runtimeclient.Client
+	var ctx context.Context
+	var platform configv1.PlatformType
+	var clusterName string
+	var failureDomain string
+	var machineTemplateName string
+	var kind string
+	var machineSetParams framework.CAPIMachineSetParams
+	var err error
+
+	BeforeAll(func() {
+		client, err = framework.LoadClient()
+		Expect(err).NotTo(HaveOccurred(), "Failed to create Kubernetes client for test")
+		komega.SetClient(client)
+		ctx = framework.GetContext()
+		platform, err = framework.GetPlatform(ctx, client)
+		Expect(err).ToNot(HaveOccurred(), "Failed to get platform")
+		oc, _ := framework.NewCLI()
+		framework.SkipIfNotTechPreviewNoUpgrade(oc, client)
+
+		infra, err := framework.GetInfrastructure(ctx, client)
+		Expect(err).NotTo(HaveOccurred(), "Failed to get cluster infrastructure object")
+		Expect(infra.Status.InfrastructureName).ShouldNot(BeEmpty(), "infrastructure name was empty on Infrastructure.Status.")
+		clusterName = infra.Status.InfrastructureName
+
+		switch platform {
+		case configv1.AWSPlatformType:
+			awsMapiMachineSpec = getDefaultAWSMAPIProviderSpec(client)
+			failureDomain = awsMapiMachineSpec.Placement.AvailabilityZone
+			kind = "AWSMachineTemplate"
+		case configv1.AzurePlatformType:
+			azureMapiMachineSpec = getAzureMAPIProviderSpec(client)
+			failureDomain = azureMapiMachineSpec.Zone
+			kind = "AzureMachineTemplate"
+		case configv1.GCPPlatformType:
+			gcpMapiMachineSpec = getGCPMAPIProviderSpec(client)
+			failureDomain = gcpMapiMachineSpec.Zone
+			kind = "GCPMachineTemplate"
+		default:
+			Skip(fmt.Sprintf("Platform %v does not support , skipping.", platform))
+		}
+
+	})
+
+	AfterEach(func() {
+		// if the current testing are skipped, we skip clean resources
+		if CurrentSpecReport().State == gotypes.SpecStateSkipped {
+			return
+		}
+
+		framework.DeleteCAPIMachineSets(ctx, client, machineSet)
+		framework.WaitForCAPIMachineSetsDeleted(ctx, client, machineSet)
+		switch platform {
+		case configv1.AWSPlatformType:
+			framework.DeleteObjects(ctx, client, awsMachineTemplate)
+		case configv1.AzurePlatformType:
+			framework.DeleteObjects(ctx, client, azureMachineTemplate)
+		case configv1.GCPPlatformType:
+			framework.DeleteObjects(ctx, client, gcpMachineTemplate)
+		default:
+			Skip(fmt.Sprintf("Platform %v does not support , skipping.", platform))
+		}
+	})
+
+	// OCP-75779 - [CAPI] Labels and annotations specified in a machineset should propagate to nodes.
+	// author: huliu@redhat.com
+	It("should be able to run a machine with labels and annotations and they are propagated to nodes", func() {
+		switch platform {
+		case configv1.AWSPlatformType:
+			machineTemplateName = "awsmachinetemplate-75779"
+			awsMachineTemplate = newAWSMachineTemplate(machineTemplateName, awsMapiMachineSpec)
+			Expect(client.Create(ctx, awsMachineTemplate)).To(Succeed(), "Failed to create awsmachinetemplate")
+		case configv1.AzurePlatformType:
+			machineTemplateName = "azuremachinetemplate-75779"
+			azureMachineTemplate = newAzureMachineTemplate(client, machineTemplateName, azureMapiMachineSpec)
+			Expect(client.Create(ctx, azureMachineTemplate)).To(Succeed(), "Failed to create azuremachinetemplate")
+		case configv1.GCPPlatformType:
+			gcpMachineTemplate = createGCPMachineTemplate(gcpMapiMachineSpec)
+			Expect(client.Create(ctx, gcpMachineTemplate)).To(Succeed(), "Failed to create gcpmachinetemplate")
+			machineTemplateName = gcpMachineTemplate.Name
+		default:
+			Skip(fmt.Sprintf("Platform %v does not support , skipping.", platform))
+		}
+
+		machineSetParams = framework.NewCAPIMachineSetParams(
+			"machineset-75779",
+			clusterName,
+			failureDomain,
+			0,
+			corev1.ObjectReference{
+				Kind:       kind,
+				APIVersion: infraAPIVersion,
+				Name:       machineTemplateName,
+			},
+		)
+		machineSet, err = framework.CreateCAPIMachineSet(ctx, client, machineSetParams)
+		Expect(err).ToNot(HaveOccurred(), "Failed to create CAPI machineset")
+
+		machineSetCopy := machineSet.DeepCopy()
+		machineSetCopy.Spec.Replicas = ptr.To(int32(1))
+		machineSetCopy.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		machineSetCopy.Spec.Template.ObjectMeta.Annotations["anno1key"] = "anno1value"
+		machineSetCopy.Spec.Template.ObjectMeta.Labels["label1key"] = "label1value"
+
+		err = client.Patch(ctx, machineSetCopy, runtimeclient.MergeFrom(machineSet))
+		Expect(err).NotTo(HaveOccurred(), "Failed to patch "+machineSet.Name)
+		framework.WaitForCAPIMachinesRunning(ctx, client, machineSet.Name)
+
+		machines, err := framework.GetCAPIMachinesFromMachineSet(ctx, client, machineSet)
+		Expect(err).NotTo(HaveOccurred(), "Failed to get machine from machineset")
+		Expect(machines[0].ObjectMeta.Annotations["anno1key"]).Should(Equal("anno1value"))
+		Expect(machines[0].ObjectMeta.Labels["label1key"]).Should(Equal("label1value"))
+
+		node, err := framework.GetCAPINodeForMachine(ctx, client, machines[0])
+		Expect(err).NotTo(HaveOccurred(), "Failed to get node from machine")
+		Expect(node.ObjectMeta.Annotations["anno1key"]).Should(Equal("anno1value"))
+		Expect(node.ObjectMeta.Labels["label1key"]).Should(Equal("label1value"))
+	})
+})


### PR DESCRIPTION
auto [OCP-75779 - [CAPI] Labels and annotations specified in a machineset should propagate to nodes](https://polarion.engineering.redhat.com/polarion/redirect/project/OSE/workitem?id=OCP-75779)
passed on AWS, Azure and GCP. @sunzhaohua2 @miyadav @shellyyang1989 PTAL, thanks!

On AWS
```
liuhuali@Lius-MacBook-Pro cluster-api-actuator-pkg % ./hack/ci-integration.sh -focus "Cluster API MachineSet" -v
Running Suite: Machine Suite - /Users/liuhuali/project/cluster-api-actuator-pkg/pkg
===================================================================================
Random Seed: 1744627579

Will run 1 of 63 specs
------------------------------
[BeforeSuite] 
/Users/liuhuali/project/cluster-api-actuator-pkg/pkg/e2e_test.go:68
[BeforeSuite] PASSED [1.371 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Cluster API MachineSet should be able to run a machine with labels and annotatioins and they are propagated to nodes [capi, disruptive]
/Users/liuhuali/project/cluster-api-actuator-pkg/pkg/capi/core.go:102
I0414 18:46:47.668856   38300 aws.go:237] Getting from machineset huliu-aws414a-5kz5s-worker-us-east-2a
  STEP: Creating AWS machine template @ 04/14/25 18:46:47.669
  STEP: Creating MachineSet "machineset-75779" @ 04/14/25 18:46:48.621
  STEP: Waiting for MachineSet machines "machineset-75779" to enter Running phase @ 04/14/25 18:46:49.773
  STEP: Deleting MachineSet "machineset-75779" @ 04/14/25 18:52:30.493
  STEP: Waiting for MachineSet "machineset-75779" to be deleted @ 04/14/25 18:52:30.8
  STEP: Deleting /aws-machine-template @ 04/14/25 18:53:34.077
• [411.974 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.007 seconds]
------------------------------

Ran 1 of 63 Specs in 413.349 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 62 Skipped
PASS

Ginkgo ran 1 suite in 7m15.42210794s
Test Suite Passed

```
On Azure
```
liuhuali@Lius-MacBook-Pro cluster-api-actuator-pkg % ./hack/ci-integration.sh -focus "Cluster API MachineSet" -v
Running Suite: Machine Suite - /Users/liuhuali/project/cluster-api-actuator-pkg/pkg
===================================================================================
Random Seed: 1744686315

Will run 1 of 63 specs
------------------------------
[BeforeSuite] 
/Users/liuhuali/project/cluster-api-actuator-pkg/pkg/e2e_test.go:68
[BeforeSuite] PASSED [0.864 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSS
------------------------------
Cluster API MachineSet should be able to run a machine with labels and annotatioins and they are propagated to nodes [capi, disruptive]
/Users/liuhuali/project/cluster-api-actuator-pkg/pkg/capi/core.go:98
  STEP: Creating Azure machine template @ 04/15/25 11:05:46.165
  STEP: Creating MachineSet "machineset-75779" @ 04/15/25 11:05:47.042
  STEP: Waiting for MachineSet machines "machineset-75779" to enter Running phase @ 04/15/25 11:05:47.833
  STEP: Deleting MachineSet "machineset-75779" @ 04/15/25 11:14:35.517
  STEP: Waiting for MachineSet "machineset-75779" to be deleted @ 04/15/25 11:14:35.726
  STEP: Deleting /azure-machine-template @ 04/15/25 11:15:17.706
• [574.775 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.011 seconds]
------------------------------

Ran 1 of 63 Specs in 575.640 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 62 Skipped
PASS

Ginkgo ran 1 suite in 10m2.240445454s
Test Suite Passed
```

On GCP
```
liuhuali@Lius-MacBook-Pro cluster-api-actuator-pkg % ./hack/ci-integration.sh -focus "Cluster API MachineSet" -v
Running Suite: Machine Suite - /Users/liuhuali/project/cluster-api-actuator-pkg/pkg
===================================================================================
Random Seed: 1744688788

Will run 1 of 63 specs
------------------------------
[BeforeSuite] 
/Users/liuhuali/project/cluster-api-actuator-pkg/pkg/e2e_test.go:68
[BeforeSuite] PASSED [1.049 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSS
------------------------------
Cluster API MachineSet should be able to run a machine with labels and annotatioins and they are propagated to nodes [capi, disruptive]
/Users/liuhuali/project/cluster-api-actuator-pkg/pkg/capi/core.go:99
  STEP: Creating GCP machine template @ 04/15/25 11:47:00.967
  STEP: Creating MachineSet "machineset-75779" @ 04/15/25 11:47:01.596
  STEP: Waiting for MachineSet machines "machineset-75779" to enter Running phase @ 04/15/25 11:47:02.571
  STEP: Deleting MachineSet "machineset-75779" @ 04/15/25 11:53:30.07
  STEP: Waiting for MachineSet "machineset-75779" to be deleted @ 04/15/25 11:53:30.42
  STEP: Deleting /gcpmachinetemplate-w65zc @ 04/15/25 11:54:03.008
• [424.584 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.009 seconds]
------------------------------

Ran 1 of 63 Specs in 425.636 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 62 Skipped
PASS

Ginkgo ran 1 suite in 7m35.037744201s
Test Suite Passed

```