### PR TITLE
NO-JIRA: fix no failureDomain failure in azure

### DIFF
--- a/pkg/framework/capi_machinesets.go
+++ b/pkg/framework/capi_machinesets.go
@@ -74,10 +74,13 @@ func CreateCAPIMachineSet(ctx context.Context, cl client.Client, params CAPIMach
 			},
 			ClusterName:       params.clusterName,
 			InfrastructureRef: params.infrastructureRef,
-			FailureDomain:     &params.failureDomain,
 		},
 	}
 	ms := capiv1resourcebuilder.MachineSet().WithName(params.msName).WithNamespace(ClusterAPINamespace).WithReplicas(params.replicas).WithClusterName(params.clusterName).WithSelector(selector).WithTemplate(template).WithLabels(map[string]string{"cluster.x-k8s.io/cluster-name": params.clusterName}).Build()
+
+	if params.failureDomain != "" {
+		ms.Spec.Template.Spec.FailureDomain = &params.failureDomain
+	}
 
 	Eventually(func() error {
 		return cl.Create(ctx, ms)


### PR DESCRIPTION
Create capi machineset in region without zones, report below error, this try to fix this issue.
```
Expected success, but got an error:
    <*errors.StatusError | 0xc000a13cc0>: 
    MachineSet.cluster.x-k8s.io "azure-machineset-75884" is invalid: spec.template.spec.failureDomain: Invalid value: "": spec.template.spec.failureDomain in body should be at least 1 chars long
```

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-api-provider-azure/335/pull-ci-openshift-cluster-api-provider-azure-master-regression-clusterinfra-azure-ipi-techpreview/1922992711938347008 