### PR TITLE
OCPQE-27646: addlabel2

### DIFF
--- a/pkg/framework/ginkgo-labels.go
+++ b/pkg/framework/ginkgo-labels.go
@@ -35,4 +35,7 @@ var (
 
 	// LabelQEOnly indicates that the test can run in qe account only.
 	LabelQEOnly = ginkgo.Label("qe-only")
+
+	// LabelConnectedOnly indicates that the test can run in a connection cluster only.
+	LabelConnectedOnly = ginkgo.Label("connected-only")
 )

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -265,7 +265,7 @@ var _ = Describe(
 
 var _ = Describe(
 	"When cluster-wide proxy is configured, Machine API cluster operator should ",
-	framework.LabelDisruptive, framework.LabelPeriodic, framework.LabelMAPI,
+	framework.LabelDisruptive, framework.LabelConnectedOnly, framework.LabelPeriodic, framework.LabelMAPI,
 	Serial,
 	func() {
 		var gatherer *gatherer.StateGatherer


### PR DESCRIPTION
Refer https://github.com/openshift/cluster-api-actuator-pkg/pull/353#issuecomment-2948288605, but I checked the code of dynamically checking if it's a disconnected cluster, it's complicated and time consuming, so I prefer to use label
@sunzhaohua2 @miyadav @shellyyang1989 PTAL, thanks!