### PR TITLE
Remove uncompressedUserData: true from test MachineTemplate

### DIFF
--- a/pkg/capi/aws.go
+++ b/pkg/capi/aws.go
@@ -292,7 +292,6 @@ func newAWSMachineTemplate(name string, mapiProviderSpec *mapiv1.AWSMachineProvi
 		}
 	}
 
-	uncompressedUserData := true
 	ami := awsv1.AMIReference{
 		ID: mapiProviderSpec.AMI.ID,
 	}
@@ -320,7 +319,6 @@ func newAWSMachineTemplate(name string, mapiProviderSpec *mapiv1.AWSMachineProvi
 	}
 
 	awsMachineSpec := awsv1.AWSMachineSpec{
-		UncompressedUserData:     &uncompressedUserData,
 		IAMInstanceProfile:       *mapiProviderSpec.IAMInstanceProfile.ID,
 		InstanceType:             mapiProviderSpec.InstanceType,
 		AMI:                      ami,


### PR DESCRIPTION
This field is unused because OpenShift does not use cloudInit. Its presence is failing test on https://github.com/openshift/cluster-capi-operator/pull/333 due to newly added validating admission policy rejecting the use of uncompressedUserData.