### PR TITLE
fix81293

### DIFF
--- a/pkg/capi/aws.go
+++ b/pkg/capi/aws.go
@@ -221,8 +221,13 @@ var _ = Describe("Cluster API AWS MachineSet", framework.LabelCAPI, framework.La
 
 	//OCP-81293 - [CAPI][AWS] Support AWS EFA network interface type in CAPI.
 	It("should be able to run a machine with EFA network interface type", func() {
+		// c5n.9xlarge with EFA may not be available in all regions
+		if mapiDefaultProviderSpec.Placement.Region != "us-east-2" && mapiDefaultProviderSpec.Placement.Region != "us-west-2" {
+			Skip("c5n.9xlarge instances with EFA support may not be available in all regions, limiting this test to us-east-2 and us-west-2")
+		}
+
 		awsMachineTemplate = newAWSMachineTemplate(awsMachineTemplateName, mapiDefaultProviderSpec)
-		awsMachineTemplate.Spec.Template.Spec.InstanceType = "m5dn.24xlarge"
+		awsMachineTemplate.Spec.Template.Spec.InstanceType = "c5n.9xlarge"
 		awsMachineTemplate.Spec.Template.Spec.NetworkInterfaceType = awsv1.NetworkInterfaceTypeEFAWithENAInterface
 		Expect(cl.Create(ctx, awsMachineTemplate)).To(Succeed(), "Failed to create awsmachinetemplate")
 		machineSetParams = framework.UpdateCAPIMachineSetName("aws-machineset-81293", machineSetParams)


### PR DESCRIPTION
Fix below error @sunzhaohua2 PTAL, thanks!
Machine Suite: [It] Cluster API AWS MachineSet should be able to run a machine with EFA network interface type [capi, disruptive]

`E0908 12:00:39.820283       1 controller.go:347] "Reconciler error" err="failed to create AWSMachine instance: failed to run instance: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: 885a4315-5d3f-4f19-b587-d91fcc3b50f3, api error Unsupported: The requested configuration is currently not supported. Please check the documentation for supported configurations." controller="awsmachine" controllerGroup="infrastructure.cluster.x-k8s.io" controllerKind="AWSMachine" AWSMachine="openshift-cluster-api/aws-machineset-81293-m9pz8" namespace="openshift-cluster-api" name="aws-machineset-81293-m9pz8" reconcileID="184a5cb8-1a43-4b47-8434-254a5e4b99f7"`