### PR TITLE
OCPBUGS-61885: fix75395

### DIFF
--- a/pkg/capi/aws.go
+++ b/pkg/capi/aws.go
@@ -104,8 +104,10 @@ var _ = Describe("Cluster API AWS MachineSet", framework.LabelCAPI, framework.La
 		Expect(err).ToNot(HaveOccurred(), "Failed to create placementgroup")
 		Expect(placementGroupID).ToNot(Equal(""), "expected the placementGroupID to not be empty string")
 		DeferCleanup(func() {
-			_, err = awsClient.DeletePlacementGroup(placementGroupName)
-			Expect(err).ToNot(HaveOccurred(), "Failed to delete placementgroup")
+			Eventually(func() error {
+				_, err = awsClient.DeletePlacementGroup(placementGroupName)
+				return err
+			}, framework.WaitShort, framework.RetryMedium).Should(Succeed(), "Failed to delete placementgroup after retries")
 		})
 
 		awsMachineTemplate = newAWSMachineTemplate(awsMachineTemplateName, mapiDefaultProviderSpec)


### PR DESCRIPTION
This is aim to fix below error reported in the [job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/354/pull-ci-openshift-cluster-capi-operator-main-regression-clusterinfra-aws-ipi-techpreview-capi/1966056178949558272) @sunzhaohua2 PTAL, thanks!


```
Machine Suite: [It] Cluster API AWS MachineSet should be able to run a machine with cluster placement group [capi, disruptive] 
{Failed to delete placementgroup
Unexpected error:
    <*fmt.wrapError | 0xc0007a5e20>: 
    could not delete placement group: InternalError: An internal error has occurred
    	status code: 500, request id: cd891311-93fd-4996-9f38-5ba5d6debb30
    {
        msg: "could not delete placement group: InternalError: An internal error has occurred\n\tstatus code: 500, request id: cd891311-93fd-4996-9f38-5ba5d6debb30",
        err: <*awserr.requestError | 0xc000869840>{
            awsError: <*awserr.baseError | 0xc000869800>{
                code: "InternalError",
                message: "An internal error has occurred",
                errs: nil,
            },
            statusCode: 500,
            requestID: "cd891311-93fd-4996-9f38-5ba5d6debb30",
            bytes: nil,
        },
    }
occurred failed [FAILED] Failed to delete placementgroup
```

