### PR TITLE
NO-JIRA: framework: fix flake on deleting machinesets

### DIFF
--- a/pkg/framework/capi_machinesets.go
+++ b/pkg/framework/capi_machinesets.go
@@ -121,7 +121,11 @@ func DeleteCAPIMachineSets(ctx context.Context, cl client.Client, machineSets ..
 	for _, ms := range machineSets {
 		By(fmt.Sprintf("Deleting MachineSet %q", ms.GetName()))
 		Eventually(func() error {
-			return cl.Delete(ctx, ms)
+			if err := cl.Delete(ctx, ms); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+
+			return nil
 		}, WaitLong, RetryShort).Should(Succeed(), "the CAPI MachineSets should have been deleted")
 	}
 }


### PR DESCRIPTION
Fixes flake where deletion succeeded but racy due to eventually and trying a gain to delete:

```
STEP: Deleting MachineSet "aws-machineset-76794" - /go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/framework/capi_machinesets.go:122 @ 09/17/25 15:18:19.147
[FAILED] Timed out after 900.001s.
the CAPI MachineSets should have been deleted
Expected success, but got an error:
    <*errors.StatusError | 0xc000d1a8c0>: 
    machinesets.cluster.x-k8s.io "aws-machineset-76794" not found
    {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {
                SelfLink: "",
                ResourceVersion: "",
                Continue: "",
                RemainingItemCount: nil,
            },
            Status: "Failure",
            Message: "machinesets.cluster.x-k8s.io \"aws-machineset-76794\" not found",
            Reason: "NotFound",
            Details: {
                Name: "aws-machineset-76794",
                Group: "cluster.x-k8s.io",
                Kind: "machinesets",
                UID: "",
                Causes: nil,
                RetryAfterSeconds: 0,
            },
            Code: 404,
        },
    }
In [AfterEach] at: /go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/framework/capi_machinesets.go:125 @ 09/17/25 15:33:19.148
< Exit [AfterEach] Cluster API AWS MachineSet - /go/src/github.com/openshift/cluster-api-actuator-pkg/pkg/capi/aws.go:83 @ 09/17/25 15:33:19.149 (15m0.001s)
```

Full logs: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/363/pull-ci-openshift-cluster-capi-operator-main-regression-clusterinfra-aws-ipi-techpreview-capi/1968297529997004800