### PR TITLE
add timeout

### DIFF
--- a/hack/ci-integration.sh
+++ b/hack/ci-integration.sh
@@ -5,7 +5,7 @@ REPORT_POSTFIX="$(date +%s)_${RANDOM}"
 
 go run ./vendor/github.com/onsi/ginkgo/v2/ginkgo \
     -v \
-    --timeout=115m \
+    --timeout=180m \
     --grace-period=5m \
     --fail-fast=false \
     --no-color \


### PR DESCRIPTION
It was observed the timeout is insufficient in https://github.com/openshift/cluster-api-actuator-pkg/pull/440 as we add more and more cases in this repo. so adding timeout from 115m to 180m
@sunzhaohua2 @miyadav PTAL, thanks!