### PR TITLE
OCPCLOUD-3466: Add E2E test for CAPI controllers cluster-wide proxy support

### DIFF
--- a/pkg/framework/proxies.go
+++ b/pkg/framework/proxies.go
@@ -45,16 +45,14 @@ import (
 )
 
 const (
-	mapiControllersDeploymentName         = "machine-api-controllers"
-	machineControllerContainerName string = "machine-controller"
-	proxyNamespace                        = MachineAPINamespace
-	proxyName                             = "mitm-proxy"
-	mitmSignerName                        = "mitm-signer"
-	mitmBootstrapName                     = "mitm-bootstrap"
-	mitmCustomPKIName                     = "mitm-custom-pki"
-	mitmCustomPKINamespace                = "openshift-config"
-	mitmDaemonsetName                     = proxyName
-	mitmServiceName                       = proxyName
+	proxyNamespace         = MachineAPINamespace
+	proxyName              = "mitm-proxy"
+	mitmSignerName         = "mitm-signer"
+	mitmBootstrapName      = "mitm-bootstrap"
+	mitmCustomPKIName      = "mitm-custom-pki"
+	mitmCustomPKINamespace = "openshift-config"
+	mitmDaemonsetName      = proxyName
+	mitmServiceName        = proxyName
 )
 
 const proxySetup = `
@@ -64,6 +62,16 @@ curl -O https://snapshots.mitmproxy.org/5.3.0/mitmproxy-5.3.0-linux.tar.gz
 tar xvf mitmproxy-5.3.0-linux.tar.gz
 HOME=/.mitmproxy ./mitmdump --ssl-insecure
 `
+
+// IsClusterProxyEnabled returns true if the cluster has a global proxy enabled.
+func IsClusterProxyEnabled(ctx context.Context, c client.Client) (bool, error) {
+	proxy := &configv1.Proxy{}
+	if err := c.Get(ctx, client.ObjectKey{Name: "cluster"}, proxy); err != nil {
+		return false, fmt.Errorf("failed to get cluster proxy: %w", err)
+	}
+
+	return len(proxy.Status.HTTPProxy) > 0 || len(proxy.Status.HTTPSProxy) > 0, nil
+}
 
 // DeployProxy deploys a MITM Proxy to the cluster.
 func DeployProxy(c client.Client, gomegaArgs ...interface{}) {
@@ -142,42 +150,11 @@ func ConfigureClusterWideProxy(c client.Client, gomegaArgs ...interface{}) {
 			Name: mitmCustomPKIName,
 		}
 	}), gomegaArgs...).Should(Succeed(), "cluster wide proxy set be able to be updated")
-
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      mapiControllersDeploymentName,
-			Namespace: proxyNamespace,
-		},
-	}
-
-	By("Waiting for machine-api-controller deployment to reflect configured cluster-wide proxy")
-
-	Eventually(kom.Object(deploy), time.Minute*5).Should(
-		HaveField("Spec.Template.Spec.Containers", ContainElement(SatisfyAll(
-			HaveField("Name", Equal(machineControllerContainerName)),
-			HaveField("Env", SatisfyAll(
-				ContainElement(SatisfyAll(
-					HaveField("Name", "NO_PROXY"),
-					HaveField("Value", Not(BeEmpty())),
-				)),
-				ContainElement(SatisfyAll(
-					HaveField("Name", "HTTPS_PROXY"),
-					HaveField("Value", Not(BeEmpty())),
-				)),
-				ContainElement(SatisfyAll(
-					HaveField("Name", "HTTP_PROXY"),
-					HaveField("Value", Not(BeEmpty())),
-				)),
-			)),
-		))),
-		"Cluster-wide proxy environment variables were not set.",
-	)
 }
 
 // UnconfigureClusterWideProxy configures the Cluster-Wide Proxy to stop using the MITM Proxy.
 func UnconfigureClusterWideProxy(c client.Client, gomegaArgs ...interface{}) {
 	ctx := context.Background()
-	kom := komega.New(c)
 
 	proxy := &configv1.Proxy{}
 	Eventually(c.Get(ctx, client.ObjectKey{Name: "cluster"}, proxy)).Should(Succeed(), "timed out getting Proxy named 'cluster.'")
@@ -188,31 +165,70 @@ func UnconfigureClusterWideProxy(c client.Client, gomegaArgs ...interface{}) {
 		{"op": "remove", "path": "/spec/noProxy"},
 		{"op": "remove", "path": "/spec/trustedCA"}
 	]`)))).Should(Succeed(), "timed out patching Proxy Spec.")
+}
+
+// WaitForAllContainersProxyEnvVars waits for all containers in the given Deployment
+// to have HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables set.
+func WaitForAllContainersProxyEnvVars(c client.Client, namespace, deploymentName string) {
+	kom := komega.New(c)
 
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      mapiControllersDeploymentName,
-			Namespace: proxyNamespace,
+			Name:      deploymentName,
+			Namespace: namespace,
 		},
 	}
 
-	By("Waiting for machine-api-controller deployment to reflect unconfigured cluster-wide proxy")
+	proxyEnvMatcher := SatisfyAll(
+		ContainElement(SatisfyAll(
+			HaveField("Name", "NO_PROXY"),
+			HaveField("Value", Not(BeEmpty())),
+		)),
+		ContainElement(SatisfyAll(
+			HaveField("Name", "HTTPS_PROXY"),
+			HaveField("Value", Not(BeEmpty())),
+		)),
+		ContainElement(SatisfyAll(
+			HaveField("Name", "HTTP_PROXY"),
+			HaveField("Value", Not(BeEmpty())),
+		)),
+	)
+
+	By(fmt.Sprintf("Waiting for all containers in %s/%s to reflect configured cluster-wide proxy", namespace, deploymentName))
+
 	Eventually(kom.Object(deploy), time.Minute*5).Should(
-		HaveField("Spec.Template.Spec.Containers", ContainElement(SatisfyAll(
-			HaveField("Name", Equal(machineControllerContainerName)),
-			HaveField("Env", SatisfyAll(
-				Not(ContainElement(SatisfyAll(
-					HaveField("Name", "NO_PROXY"),
-				))),
-				Not(ContainElement(SatisfyAll(
-					HaveField("Name", "HTTPS_PROXY"),
-				))),
-				Not(ContainElement(SatisfyAll(
-					HaveField("Name", "HTTP_PROXY"),
-				))),
-			)),
+		HaveField("Spec.Template.Spec.Containers", Not(ContainElement(
+			HaveField("Env", Not(proxyEnvMatcher)),
 		))),
-		"Cluster-wide proxy environmenet variables were still set.",
+		fmt.Sprintf("Cluster-wide proxy environment variables were not set on all containers of %s/%s.", namespace, deploymentName),
+	)
+}
+
+// WaitForAllContainersNoProxyEnvVars waits for all containers in the given Deployment
+// to have HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables removed.
+func WaitForAllContainersNoProxyEnvVars(c client.Client, namespace, deploymentName string) {
+	kom := komega.New(c)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: namespace,
+		},
+	}
+
+	noProxyEnvMatcher := SatisfyAll(
+		Not(ContainElement(HaveField("Name", "NO_PROXY"))),
+		Not(ContainElement(HaveField("Name", "HTTPS_PROXY"))),
+		Not(ContainElement(HaveField("Name", "HTTP_PROXY"))),
+	)
+
+	By(fmt.Sprintf("Waiting for all containers in %s/%s to reflect unconfigured cluster-wide proxy", namespace, deploymentName))
+
+	Eventually(kom.Object(deploy), time.Minute*5).Should(
+		HaveField("Spec.Template.Spec.Containers", Not(ContainElement(
+			HaveField("Env", Not(noProxyEnvMatcher)),
+		))),
+		fmt.Sprintf("Cluster-wide proxy environment variables were still set on some containers of %s/%s.", namespace, deploymentName),
 	)
 }
 

--- a/pkg/operators/cluster-capi-operator.go
+++ b/pkg/operators/cluster-capi-operator.go
@@ -1,0 +1,133 @@
+package operators
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework"
+	"github.com/openshift/cluster-api-actuator-pkg/pkg/framework/gatherer"
+)
+
+var _ = Describe(
+	"[sig-cluster-lifecycle] Cluster API When cluster-wide proxy is configured, Cluster API provider deployments should",
+	framework.LabelDisruptive, framework.LabelConnectedOnly, framework.LabelPeriodic, framework.LabelCAPI,
+	Serial,
+	func() {
+		var (
+			gatherer   *gatherer.StateGatherer
+			client     runtimeclient.Client
+			ctx        context.Context
+			isProxyJob bool
+		)
+
+		BeforeEach(func() {
+			var err error
+
+			client, err = framework.LoadClient()
+			Expect(err).NotTo(HaveOccurred(), "Failed to load client")
+
+			ctx = framework.GetContext()
+
+			gatherer, err = framework.NewGatherer()
+			Expect(err).ToNot(HaveOccurred(), "Failed to load gatherer")
+
+			isProxyJob, err = framework.IsClusterProxyEnabled(ctx, client)
+			Expect(err).ToNot(HaveOccurred(), "Failed to check cluster proxy configuration")
+
+			if isProxyJob {
+				By("cluster-wide proxy is already configured on proxy cluster, skipping MITM proxy deployment")
+			} else {
+				By("deploying an HTTP proxy")
+				framework.DeployProxy(client)
+
+				By("configuring cluster-wide proxy")
+				framework.ConfigureClusterWideProxy(client)
+			}
+		})
+
+		It("have proxy environment variables injected", func() {
+			By("waiting for Cluster API provider deployments to reflect proxy configuration")
+
+			deployments := &appsv1.DeploymentList{}
+			Eventually(client.List(ctx, deployments,
+				runtimeclient.InNamespace(framework.ClusterAPINamespace),
+				runtimeclient.HasLabels{"cluster.x-k8s.io/provider"},
+			)).Should(Succeed(), "timed out listing Cluster API provider Deployments.")
+			Expect(deployments.Items).NotTo(BeEmpty(), "no Cluster API provider Deployments found")
+
+			for _, deploy := range deployments.Items {
+				By(fmt.Sprintf("verifying proxy env vars on Deployment %s", deploy.Name))
+				framework.WaitForAllContainersProxyEnvVars(client, framework.ClusterAPINamespace, deploy.Name)
+			}
+		})
+
+		AfterEach(func() {
+			specReport := CurrentSpecReport()
+			if specReport.Failed() {
+				Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed(), "Failed to GatherAll")
+			}
+
+			if isProxyJob {
+				By("cluster-wide proxy was pre-existing, skipping MITM proxy cleanup")
+				return
+			}
+
+			By("unconfiguring cluster-wide proxy")
+			framework.UnconfigureClusterWideProxy(client)
+
+			var err error
+
+			client, err = framework.LoadClient()
+			Expect(err).NotTo(HaveOccurred(), "Failed to refresh client after proxy teardown")
+
+			By("verifying proxy env vars are removed from Cluster API provider Deployments")
+
+			deployments := &appsv1.DeploymentList{}
+			Eventually(client.List(ctx, deployments,
+				runtimeclient.InNamespace(framework.ClusterAPINamespace),
+				runtimeclient.HasLabels{"cluster.x-k8s.io/provider"},
+			)).Should(Succeed(), "timed out listing Cluster API provider Deployments.")
+			Expect(deployments.Items).NotTo(BeEmpty(), "no Cluster API provider Deployments found")
+
+			for _, deploy := range deployments.Items {
+				By(fmt.Sprintf("verifying proxy env vars removed from Deployment %s", deploy.Name))
+				framework.WaitForAllContainersNoProxyEnvVars(client, framework.ClusterAPINamespace, deploy.Name)
+			}
+
+			By("waiting for KAPI cluster operator to become available")
+			Expect(framework.WaitForStatusAvailableOverLong(ctx, client, "kube-apiserver")).To(BeTrue(),
+				"Failed to wait for kube-apiserver Cluster Operator to become available")
+
+			By("waiting for KCM cluster operator to become available")
+			Expect(framework.WaitForStatusAvailableOverLong(ctx, client, "kube-controller-manager")).To(BeTrue(),
+				"Failed to wait for kube-controller-manager Cluster Operator to become available")
+
+			By("waiting for cluster-api cluster operator to become available")
+			Expect(framework.WaitForStatusAvailableMedium(ctx, client, "cluster-api")).To(BeTrue(),
+				"Failed to wait for cluster-api Cluster Operator to become available")
+
+			By("waiting for all nodes to become ready")
+			Expect(framework.WaitUntilAllNodesAreReady(ctx, client)).To(Succeed(),
+				"Failed to wait for all nodes to become ready")
+
+			By("waiting for all cluster operators to become available")
+
+			coList := &configv1.ClusterOperatorList{}
+			Eventually(client.List(ctx, coList)).Should(Succeed(), "failed to list ClusterOperators.")
+
+			for _, co := range coList.Items {
+				Expect(framework.WaitForStatusAvailableOverLong(ctx, client, co.Name)).To(BeTrue(),
+					"Failed to wait for %s Cluster Operator to become available", co.Name)
+			}
+
+			By("removing the mitm-proxy")
+			framework.DeleteProxy(client)
+		})
+	})

--- a/pkg/operators/machine-api-operator.go
+++ b/pkg/operators/machine-api-operator.go
@@ -272,9 +272,10 @@ var _ = Describe(
 	Serial,
 	func() {
 		var (
-			gatherer *gatherer.StateGatherer
-			client   runtimeclient.Client
-			ctx      context.Context
+			gatherer   *gatherer.StateGatherer
+			client     runtimeclient.Client
+			ctx        context.Context
+			isProxyJob bool
 		)
 
 		BeforeEach(func() {
@@ -288,11 +289,21 @@ var _ = Describe(
 			gatherer, err = framework.NewGatherer()
 			Expect(err).ToNot(HaveOccurred(), "Failed to load gatherer")
 
-			By("deploying an HTTP proxy")
-			framework.DeployProxy(client)
+			isProxyJob, err = framework.IsClusterProxyEnabled(ctx, client)
+			Expect(err).ToNot(HaveOccurred(), "Failed to check cluster proxy configuration")
 
-			By("configuring cluster-wide proxy")
-			framework.ConfigureClusterWideProxy(client)
+			if isProxyJob {
+				By("cluster-wide proxy is already configured on proxy cluster, skipping MITM proxy deployment")
+			} else {
+				By("deploying an HTTP proxy")
+				framework.DeployProxy(client)
+
+				By("configuring cluster-wide proxy")
+				framework.ConfigureClusterWideProxy(client)
+			}
+
+			By("waiting for machine-api-controllers to reflect proxy configuration")
+			framework.WaitForAllContainersProxyEnvVars(client, framework.MachineAPINamespace, maoManagedDeployment)
 		})
 
 		// Machines required for test: 1
@@ -312,13 +323,21 @@ var _ = Describe(
 		})
 
 		AfterEach(func() {
-			By("unconfiguring cluster-wide proxy")
-			framework.UnconfigureClusterWideProxy(client)
-
 			specReport := CurrentSpecReport()
 			if specReport.Failed() {
 				Expect(gatherer.WithSpecReport(specReport).GatherAll()).To(Succeed(), "Failed to GatherAll")
 			}
+
+			if isProxyJob {
+				By("cluster-wide proxy was pre-existing, skipping MITM proxy cleanup")
+				return
+			}
+
+			By("unconfiguring cluster-wide proxy")
+			framework.UnconfigureClusterWideProxy(client)
+
+			By("waiting for machine-api-controllers to reflect proxy removal")
+			framework.WaitForAllContainersNoProxyEnvVars(client, framework.MachineAPINamespace, maoManagedDeployment)
 
 			By("waiting for MAO, KAPI and KCM cluster operators to become available")
 


### PR DESCRIPTION
_Depends on openshift/cluster-capi-operator#517_

### Summary
- Refactor proxy env var verification helpers from MAPI-specific to generic, enabling reuse for CAPI proxy tests
- Skip self MITM proxy deployment for pre-configured proxy clusters (can be obtained via prow CI workflow like `openshift-e2e-aws-proxy`)
- Add E2E test verifying CAPI provider deployments get proxy env vars injected when cluster-wide proxy is configured


### Validation

I didn't follow the MAPI ones to add a dedicate test for testing machine provisioning through a proxy, since it might require a bit refactor/framework work, which better to be a follow-up. Instead I ran the full set of CAPI tests on some pj-rehearsal clusters.

- Clusters with proxy enabled by default

- [x] New CAPI proxy test passing
- [x] Existing MAPI tests still passing

- Clusters without proxy enabled

- [x] New CAPI proxy test passing
- [x] Existing MAPI tests still passing
