### PR TITLE
PIXAA-7: Update Azure spot E2E to support rebalance recommendation

### DIFF
--- a/pkg/infra/mock/metadata_mock.go
+++ b/pkg/infra/mock/metadata_mock.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync/atomic"
 )
 
 const (
@@ -13,7 +14,7 @@ const (
 	awsTokenPattern            = "/latest/api/token"
 	gcpTerminationPattern      = "/computeMetadata/v1/instance/preempted"
 	azureTerminationPattern    = "/metadata/scheduledevents"
-	azureTerminationAPIVersion = "2019-08-01"
+	azureTerminationAPIVersion = "2024-07-09"
 )
 
 func main() {
@@ -81,7 +82,7 @@ func awsMetadataMockHandler() http.Handler {
 // Azure instances expect an OK response with a Json body containing a schedule peremption event to
 // indicate that the instance has been scheduled for termination.
 // Requires the header "Metadata: true".
-// Requires a query with the api version: eg `?api-version=2019-08-01`.
+// Requires a query with the api version: eg `?api-version=2024-07-09`.
 func azureMetadataMockHandler() http.Handler {
 	mux := http.NewServeMux()
 
@@ -99,19 +100,36 @@ func azureMetadataMockHandler() http.Handler {
 
 		if req.URL.Query().Get("api-version") != azureTerminationAPIVersion {
 			// Require the "api-version" query string to be correct
-			rw.WriteHeader(http.StatusBadRequest)
+			rw.WriteHeader(http.StatusNotFound)
 
-			if _, err := rw.Write([]byte("400 Bad Request")); err != nil {
+			if _, err := rw.Write([]byte("404 Not Found")); err != nil {
 				log.Fatal(err)
 			}
 
 			return
 		}
 
+		// Alternate between responding with the two event types.
+		var currentEventType string
+
+		lastEventType, ok := lastAzureEventType.Load().(string)
+		if !ok {
+			log.Fatal("Failed to load last Azure event type")
+		}
+
+		switch lastEventType {
+		case azureSpotRebalanceRecommendation:
+			currentEventType = azurePreemptEventType
+			lastAzureEventType.Store(azurePreemptEventType)
+		case azurePreemptEventType:
+			currentEventType = azureSpotRebalanceRecommendation
+			lastAzureEventType.Store(azureSpotRebalanceRecommendation)
+		}
+
 		events := azureScheduledEvents{
 			Events: []azureEvent{
 				{
-					EventType: azurePreemptEventType,
+					EventType: currentEventType,
 				},
 			},
 		}
@@ -135,7 +153,18 @@ func azureMetadataMockHandler() http.Handler {
 	return mux
 }
 
-const azurePreemptEventType = "Preempt"
+const (
+	azurePreemptEventType            = "Preempt"
+	azureSpotRebalanceRecommendation = "SpotRebalanceRecommendation"
+)
+
+// The last event type that was returned by the Azure metadata mock handler.
+// The mock will alternate between the two event types.
+var lastAzureEventType atomic.Value
+
+func init() {
+	lastAzureEventType.Store(azureSpotRebalanceRecommendation)
+}
 
 // azureScheduledEvents represents metadata response, more detailed info can be found here:
 // https://docs.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events#use-the-api

--- a/pkg/infra/spot.go
+++ b/pkg/infra/spot.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,9 +30,6 @@ import (
 )
 
 const (
-	// Spot machineSet replicas.
-	machinesCount = 1
-
 	// Maximum retries when provisioning a spot machineSet.
 	spotMachineSetMaxProvisioningRetryCount = 3
 )
@@ -43,17 +38,21 @@ var _ = Describe("[sig-cluster-lifecycle] Machine API Running on Spot", framewor
 	var ctx = context.Background()
 
 	var (
-		client     runtimeclient.Client
-		machineSet *machinev1.MachineSet
-		platform   configv1.PlatformType
-		arch       string
-		delObjects map[string]runtimeclient.Object
+		client        runtimeclient.Client
+		machineSet    *machinev1.MachineSet
+		platform      configv1.PlatformType
+		arch          string
+		delObjects    map[string]runtimeclient.Object
+		machinesCount int
 	)
 
 	var gatherer *gatherer.StateGatherer
 
 	BeforeEach(func() {
 		delObjects = make(map[string]runtimeclient.Object)
+
+		// Spot machineSet replicas.
+		machinesCount = 1
 
 		// Make sure to clean up the resources we created
 		DeferCleanup(func() {
@@ -89,8 +88,12 @@ var _ = Describe("[sig-cluster-lifecycle] Machine API Running on Spot", framewor
 		Expect(err).NotTo(HaveOccurred(), "Should be able to get Platform type")
 
 		switch platform {
-		case configv1.AWSPlatformType, configv1.AzurePlatformType:
+		case configv1.AWSPlatformType:
 			// Supported platforms, ok to continue.
+		case configv1.AzurePlatformType:
+			// Supported platforms, ok to continue.
+			// There are two different event types that trigger a machine deletion, so we need to create two machines.
+			machinesCount = 2
 		case configv1.GCPPlatformType:
 			// TODO: GCP relies on the metadata IP for DNS.
 			// This test prevents it from accessing the DNS, therefore
@@ -259,19 +262,7 @@ var _ = Describe("[sig-cluster-lifecycle] Machine API Running on Spot", framewor
 				Expect(framework.IsDeploymentAvailable(ctx, client, deployment.Name, deployment.Namespace)).To(BeTrue(), "Should find an available the metadata Deployment")
 			})
 
-			var machine *machinev1.Machine
-
-			By("Choosing a Machine to terminate", func() {
-				machines, err := framework.GetMachinesFromMachineSet(ctx, client, machineSet)
-				Expect(err).ToNot(HaveOccurred(), "Should be able to get Machines from MachineSet")
-				Expect(len(machines)).To(BeNumerically(">", 0), "There should be at least one Machine")
-
-				customRand := rand.New(rand.NewSource(time.Now().Unix()))
-				machine = machines[customRand.Intn(len(machines))]
-				Expect(machine.Status.NodeRef).ToNot(BeNil(), "Machine should have a linked Node")
-			})
-
-			By("Deploying a job to reroute metadata traffic to the mock", func() {
+			By("Deploying a termination simulator job supporting resources", func() {
 				serviceAccount := getTerminationSimulatorServiceAccount()
 				Expect(client.Create(ctx, serviceAccount)).To(Succeed(), "Should be able to create termination simulator ServiceAccount")
 				delObjects[serviceAccount.Name] = serviceAccount
@@ -283,16 +274,24 @@ var _ = Describe("[sig-cluster-lifecycle] Machine API Running on Spot", framewor
 				roleBinding := getTerminationSimulatorRoleBinding()
 				Expect(client.Create(ctx, roleBinding)).To(Succeed(), "Should be able to create termination simulator RoleBinding")
 				delObjects[roleBinding.Name] = roleBinding
-
-				job := getTerminationSimulatorJob(machine.Status.NodeRef.Name)
-				Expect(client.Create(ctx, job)).To(Succeed(), "Should be able to create termination simulator Job")
-				delObjects[job.Name] = job
 			})
 
-			// If the job deploys correctly, the Machine will go away
-			By(fmt.Sprintf("Waiting for machine %q to be deleted", machine.Name), func() {
-				framework.WaitForMachinesDeleted(client, machine)
-			})
+			machines, err := framework.GetMachinesFromMachineSet(ctx, client, machineSet)
+			Expect(err).ToNot(HaveOccurred(), "Should be able to get Machines from MachineSet")
+			Expect(len(machines)).To(BeNumerically(">", 0), "There should be at least one Machine")
+
+			for _, machine := range machines {
+				By("Deploying a job to reroute metadata traffic to the mock", func() {
+					job := getTerminationSimulatorJob(machine.Status.NodeRef.Name)
+					Expect(client.Create(ctx, job)).To(Succeed(), "Should be able to create termination simulator Job")
+					delObjects[job.Name] = job
+				})
+
+				// If the job deploys correctly, the Machine will go away
+				By(fmt.Sprintf("Waiting for machine %q to be deleted", machine.Name), func() {
+					framework.WaitForMachinesDeleted(client, machine)
+				})
+			}
 		})
 	})
 })
@@ -545,7 +544,7 @@ echo "Redirected metadata service to ${SERVICE_IP}:${MOCK_SERVICE_PORT}";`
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      terminationSimulatorName,
+			Name:      terminationSimulatorName + "-" + nodeName,
 			Namespace: framework.MachineAPINamespace,
 		},
 		Spec: batchv1.JobSpec{


### PR DESCRIPTION
This updates the Azure spot testing E2E test to deploy 2 instances, and return `Preempt` and `SpotRebalanceRecommendation` events alternatively. This should allow us to test somewhat at random that both event types are being observed by the termination handler and acted upon correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure metadata mock now enforces api-version, returning 404 for mismatches.
  * Mocked Azure scheduled-events alternate event types across requests.

* **Tests**
  * Spot tests set expected machine counts per platform (Azure uses two).
  * Termination-event tests simulate termination for every machine and validate per-node job handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->