### PR TITLE
OCPCLOUD-3606: align CI images and envtest with k8s 1.36

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,3 +1,3 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0
 WORKDIR /go/src/github.com/openshift/cluster-api-actuator-pkg
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export GOPROXY
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 GOLANGCI_LINT = go run ${PROJECT_DIR}/vendor/github.com/golangci/golangci-lint/v2/cmd/golangci-lint
-BUILD_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
+BUILD_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0
 
 NO_DOCKER ?= 1
 

--- a/testutils/Makefile
+++ b/testutils/Makefile
@@ -6,7 +6,7 @@ GOPROXY ?=
 export GOPROXY
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.34.1
+ENVTEST_K8S_VERSION = 1.36.2
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 ENVTEST = go run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest


### PR DESCRIPTION
## Summary
- Align `Dockerfile.ci` and `Makefile` `BUILD_IMAGE` with the golang-1.26 / openshift-5.0 builder already set in `.ci-operator.yaml` by #489
- Bump `testutils` `ENVTEST_K8S_VERSION` from 1.34.1 to **1.36.2** (present in [openshift/api envtest-releases](https://github.com/openshift/api/blob/master/envtest-releases.yaml))

Follow-up to #489 (go.mod / k8s 0.36.2 bump).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->